### PR TITLE
Add Codacy coverage reporting to Azure Pipelines

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -70,37 +70,6 @@ stages:
               fi
             displayName: 'Publish to NPM'
 
-name: Codacy Coverage
-
-on:
-  push:
-    branches: [main]
-  pull_request:
-
-jobs:
-  test-and-report:
-    runs-on: ubuntu-latest
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v3
-
-      - name: Set up Node.js
-        uses: actions/setup-node@v3
-        with:
-          node-version: 18
-
-      - name: Install dependencies
-        run: npm ci
-
-      - name: Run tests and collect coverage
-        run: npx jest --coverage
-
-      - name: Upload coverage to Codacy
-        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
-        env:
-          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
-
   - stage: CodacyCoverage
     displayName: 'Codacy Coverage'
     dependsOn: []

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -100,3 +100,34 @@ jobs:
         run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
         env:
           CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}
+
+  - stage: CodacyCoverage
+    displayName: 'Codacy Coverage'
+    dependsOn: []
+    jobs:
+      - job: ReportCoverage
+        displayName: 'Report Coverage to Codacy'
+        pool:
+          vmImage: 'ubuntu-latest'
+        steps:
+          - checkout: self
+          - task: NodeTool@0
+            inputs:
+              versionSpec: '18.x'
+            displayName: 'Set up Node.js'
+          - script: npm ci
+            displayName: 'Install dependencies'
+          - script: npx jest --coverage
+            displayName: 'Run tests and collect coverage'
+          - task: Bash@3
+            displayName: Create And Publish Codacy Report
+            condition: succeeded()
+            inputs:
+              targetType: 'inline'
+              script: |
+                # Fetch Codacy API token from AWS SSM
+                export CODACY_API_TOKEN=$(aws ssm get-parameter --with-decryption --name /devops/token/codacy | jq -r .Parameter.Value)
+                export CODACY_ORGANIZATION_PROVIDER=gh
+                export CODACY_USERNAME=lsportsltd
+                export CODACY_PROJECT_NAME=$(cut -d'/' -f2 <<<"$(Build.Repository.Name)")
+                bash <(curl -Ls https://coverage.codacy.com/get.sh) report -l JavaScript -r coverage/lcov.info

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -69,3 +69,34 @@ stages:
                 exit 1
               fi
             displayName: 'Publish to NPM'
+
+name: Codacy Coverage
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  test-and-report:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v3
+        with:
+          node-version: 18
+
+      - name: Install dependencies
+        run: npm ci
+
+      - name: Run tests and collect coverage
+        run: npx jest --coverage
+
+      - name: Upload coverage to Codacy
+        run: bash <(curl -Ls https://coverage.codacy.com/get.sh) report -r coverage/lcov.info
+        env:
+          CODACY_PROJECT_TOKEN: ${{ secrets.CODACY_PROJECT_TOKEN }}

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -77,7 +77,7 @@ stages:
       - job: ReportCoverage
         displayName: 'Report Coverage to Codacy'
         pool:
-          vmImage: 'ubuntu-latest'
+          name: k8s-agents-ci
         steps:
           - checkout: self
           - task: NodeTool@0
@@ -86,15 +86,13 @@ stages:
             displayName: 'Set up Node.js'
           - script: npm ci
             displayName: 'Install dependencies'
-          - script: npx jest --coverage
-            displayName: 'Run tests and collect coverage'
           - task: Bash@3
             displayName: Create And Publish Codacy Report
             condition: succeeded()
             inputs:
               targetType: 'inline'
               script: |
-                # Fetch Codacy API token from AWS SSM
+                npx jest --coverage
                 export CODACY_API_TOKEN=$(aws ssm get-parameter --with-decryption --name /devops/token/codacy | jq -r .Parameter.Value)
                 export CODACY_ORGANIZATION_PROVIDER=gh
                 export CODACY_USERNAME=lsportsltd


### PR DESCRIPTION
- Introduced a new job for testing and reporting coverage to Codacy.
- Configured the pipeline to run tests using Jest and collect coverage data.
- Added steps for checking out the code, setting up Node.js, installing dependencies, and uploading coverage reports to Codacy.
- This enhancement ensures better visibility of code coverage metrics in the CI/CD process.