### PR TITLE
Enhance Jest configuration for coverage reporting

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -17,4 +17,10 @@ module.exports = {
       tsconfig: '<rootDir>/tsconfig.json',
     },
   },
+  // Ensure coverage paths are relative to repository root
+  coveragePathIgnorePatterns: ['/node_modules/', '/dist/'],
+  rootDir: '.',
+  cwd: process.cwd(),
+  // Map absolute paths to relative in coverage report
+  coverageProvider: 'v8',
 }; 


### PR DESCRIPTION
- Added coveragePathIgnorePatterns to exclude node_modules and dist from coverage.
- Set rootDir and cwd for better path resolution.
- Specified coverageProvider as 'v8' to improve coverage report accuracy.