### PR TITLE
Refactor logger imports to use relative paths for consistency across …

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "1.0.5",
+  "version": "1.0.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/sample/customer-api-sample/package-lock.json
+++ b/sample/customer-api-sample/package-lock.json
@@ -21,7 +21,7 @@
       }
     },
     "../..": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/sample/feed-sample/package-lock.json
+++ b/sample/feed-sample/package-lock.json
@@ -23,7 +23,7 @@
       }
     },
     "../..": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/sample/snapshot-api-sample/package-lock.json
+++ b/sample/snapshot-api-sample/package-lock.json
@@ -21,7 +21,7 @@
       }
     },
     "../..": {
-      "version": "1.0.5",
+      "version": "1.0.6",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/src/api/base-http-client/base-http-client.ts
+++ b/src/api/base-http-client/base-http-client.ts
@@ -7,7 +7,8 @@ import { BaseEntity, Constructor } from '@entities';
 import { HttpResponseError } from '@lsports/errors';
 import { AxiosService } from '@httpClient/services';
 import { RequestSettingsValidator } from '@httpClient/validators';
-import { ConsoleAdapter, ILogger } from '@logger';
+import { ConsoleAdapter } from '../../logger/adapters';
+import { ILogger } from '../../logger/interfaces';
 import { TransformerUtil } from '@utilities';
 
 import { IHttpService, IRequestArgs } from './interfaces';

--- a/src/api/common/interfaces/http-service-config.interface.ts
+++ b/src/api/common/interfaces/http-service-config.interface.ts
@@ -1,5 +1,5 @@
 import { PackageCredentials } from '@entities';
-import { ILogger } from '@logger';
+import { ILogger } from '../../../logger/interfaces';
 
 /**
  * HTTP service configuration interface. It contains

--- a/src/feed/feed.ts
+++ b/src/feed/feed.ts
@@ -2,7 +2,8 @@ import { isNil } from 'lodash';
 
 import { BaseEntity, Constructor } from '@entities';
 import { IEntityHandler, IFeed, MQSettingsOptions } from '@feed';
-import { ConsoleAdapter, ILogger } from '@logger';
+import { ConsoleAdapter } from '../logger/adapters';
+import { ILogger } from '../logger/interfaces';
 import { DistributionUtil, withRetry } from '@utilities';
 
 import { MessageConsumerMQ } from './mq-feed';

--- a/src/feed/mq-feed/message-consumer/handler/body-handler.ts
+++ b/src/feed/mq-feed/message-consumer/handler/body-handler.ts
@@ -3,7 +3,7 @@ import { isNil } from 'lodash';
 import { IEntityHandler } from '@feed';
 import { BaseEntity } from '@entities';
 import { TransformerUtil } from '@utilities';
-import { ILogger } from '@logger';
+import { ILogger } from '../../../../logger/interfaces';
 
 import { IBodyHandler, IMessageStructure } from '../interfaces';
 

--- a/src/feed/mq-feed/message-consumer/message-consumer.ts
+++ b/src/feed/mq-feed/message-consumer/message-consumer.ts
@@ -9,7 +9,7 @@ import {
 } from '@entities';
 import { IEntityHandler } from '@feed';
 import { TransformerUtil } from '@utilities';
-import { ILogger } from '@logger';
+import { ILogger } from '../../../logger/interfaces';
 
 import { BodyHandler } from './handler';
 import { IBodyHandler, IConsumptionLatency } from './interfaces';

--- a/src/feed/mq-feed/rabbitmq-feed.ts
+++ b/src/feed/mq-feed/rabbitmq-feed.ts
@@ -3,7 +3,8 @@ import { isNil } from 'lodash';
 
 import { BaseEntity, Constructor } from '@entities';
 import { IEntityHandler, IFeed, MQSettingsOptions } from '@feed';
-import { ConsoleAdapter, ILogger } from '@logger';
+import { ConsoleAdapter } from '../../logger/adapters';
+import { ILogger } from '../../logger/interfaces';
 import { ConsumptionMessageError } from '@lsports/errors';
 import { AsyncLock, withRetry } from '@utilities';
 

--- a/src/utilities/distribution-util.ts
+++ b/src/utilities/distribution-util.ts
@@ -1,7 +1,7 @@
 import { isNil } from 'lodash';
 
 import { MQSettingsOptions } from '@feed';
-import { ILogger } from '@logger';
+import { ILogger } from '../logger/interfaces';
 import {
   HttpRequestDto,
   StartResponseBody,

--- a/src/utilities/retry-util.ts
+++ b/src/utilities/retry-util.ts
@@ -1,5 +1,5 @@
 import { RetryError } from '@lsports/errors';
-import { ILogger } from '@logger';
+import { ILogger } from '../logger/interfaces';
 
 /**
  * Retry options for retrying an operation with


### PR DESCRIPTION
update the SDK to avoid requiring consumers to use module-alias.

https://lsports-data.atlassian.net/browse/TR-17890