### PR TITLE
Fix tr 18181 change date fields from moment to number

### DIFF
--- a/src/api/common/snapshot/dtos/event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/event-request.dto.ts
@@ -25,15 +25,15 @@ export class GetEventRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/event-request.dto.ts
@@ -1,17 +1,16 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 
 /**
  * GetEventRequestDto class for sending request
  * to get event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the event
- * @param locationIds The location IDs to filter the event
- * @param leagueIds The league IDs to filter the event
- * @param fixtureIds The fixture IDs to filter the event
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the event
+ * @param locations The location IDs to filter the event
+ * @param leagues The league IDs to filter the event
+ * @param fixtures The fixture IDs to filter the event
  * @returns GetEventRequestDto instance that
  * contains the properties for the request to get
  * event from the API.
@@ -25,16 +24,16 @@ export class GetEventRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/fixture-request.dto.ts
+++ b/src/api/common/snapshot/dtos/fixture-request.dto.ts
@@ -23,15 +23,15 @@ export class GetFixtureRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/fixture-request.dto.ts
+++ b/src/api/common/snapshot/dtos/fixture-request.dto.ts
@@ -1,16 +1,15 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetFixtureRequestDto class for sending request
  * to get fixture from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the fixture
- * @param locationIds The location IDs to filter the fixture
- * @param leagueIds The league IDs to filter the fixture
- * @param fixtureIds The fixture IDs to filter the fixture
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the fixture
+ * @param locations The location IDs to filter the fixture
+ * @param leagues The league IDs to filter the fixture
+ * @param fixtures The fixture IDs to filter the fixture
  * @returns GetFixtureRequestDto instance that
  * contains the properties for the request to get
  * fixture from the API.
@@ -23,16 +22,16 @@ export class GetFixtureRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/inplay-event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/inplay-event-request.dto.ts
@@ -1,20 +1,20 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetInPlayEventRequestDto class for sending request
- * to get event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the event
- * @param locationIds The location IDs to filter the event
- * @param leagueIds The league IDs to filter the event
- * @param fixtureIds The fixture IDs to filter the event
- * @param marketIds The IDs of the markets
+ 
+ * to get inplay event from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the inplay event
+ * @param locations The location IDs to filter the inplay event
+ * @param leagues The league IDs to filter the inplay event
+ * @param fixtures The fixture IDs to filter the inplay event
+ * @param markets The IDs of the markets
  * @returns GetInPlayEventRequestDto instance that
  * contains the properties for the request to get
- * event from the API.
+ * inplay event from the API.
  */
 
 export class GetInPlayEventRequestDto implements BaseEntity {
@@ -25,16 +25,16 @@ export class GetInPlayEventRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/inplay-event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/inplay-event-request.dto.ts
@@ -26,15 +26,15 @@ export class GetInPlayEventRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/livescore-request.dto.ts
+++ b/src/api/common/snapshot/dtos/livescore-request.dto.ts
@@ -1,17 +1,16 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetLiveScoreRequestDto class for sending request
  * to get livescore from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the livescore
- * @param locationIds The location IDs to filter the livescore
- * @param leagueIds The league IDs to filter the livescore
- * @param fixtureIds The fixture IDs to filter the livescore
- * @returns GetLiveScoreRequestDto instance that
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the livescore
+ * @param locations The location IDs to filter the livescore
+ * @param leagues The league IDs to filter the livescore
+ * @param fixtures The fixture IDs to filter the livescore
+ * @returns GetLivescoreRequestDto instance that
  * contains the properties for the request to get
  * livescore from the API.
  */
@@ -23,16 +22,16 @@ export class GetLivescoreRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/livescore-request.dto.ts
+++ b/src/api/common/snapshot/dtos/livescore-request.dto.ts
@@ -23,15 +23,15 @@ export class GetLivescoreRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/market-request.dto.ts
@@ -23,15 +23,15 @@ export class GetMarketRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/market-request.dto.ts
@@ -1,16 +1,15 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetMarketRequestDto class for sending request
  * to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the market
+ * @param locations The location IDs to filter the market
+ * @param leagues The league IDs to filter the market
+ * @param fixtures The fixture IDs to filter the market
  * @returns GetMarketRequestDto instance that
  * contains the properties for the request to get
  * market from the API.
@@ -23,16 +22,16 @@ export class GetMarketRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-event-request.dto.ts
@@ -26,15 +26,15 @@ export class GetOutrightEventRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-event-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-event-request.dto.ts
@@ -1,21 +1,20 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetOutrightEventRequestDto class for sending request
  * to get outright event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
- * @param tournamentsIds The IDs of the markets
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright event
+ * @param locations The location IDs to filter the outright event
+ * @param leagues The league IDs to filter the outright event
+ * @param fixtures The fixture IDs to filter the outright event
+ * @param markets The IDs of the markets
+ * @param tournaments The tournament IDs to filter the outright event
  * @returns GetOutrightEventRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright event from the API.
  */
 
 export class GetOutrightEventRequestDto implements BaseEntity {
@@ -26,16 +25,16 @@ export class GetOutrightEventRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-fixture-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-fixture-request.dto.ts
@@ -24,15 +24,15 @@ export class GetOutrightFixtureRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-fixture-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-fixture-request.dto.ts
@@ -1,19 +1,18 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetOutrightFixtureRequestDto class for sending request
  * to get outright fixture from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param tournamentsIds The IDs of the markets
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright fixture
+ * @param locations The location IDs to filter the outright fixture
+ * @param fixtures The fixture IDs to filter the outright fixture
+ * @param tournaments The tournament IDs to filter the outright fixture
  * @returns GetOutrightFixtureRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright fixture from the API.
  */
 
 export class GetOutrightFixtureRequestDto implements BaseEntity {
@@ -24,16 +23,16 @@ export class GetOutrightFixtureRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-league-market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-league-market-request.dto.ts
@@ -1,20 +1,19 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
- * GetOutrightLeagueMarketRequesttDto class for sending request
+ * GetOutrightLeagueMarketRequestDto class for sending request
  * to get outright league market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
- * @returns GetOutrightLeagueMarketRequesttDto instance that
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright league market
+ * @param locations The location IDs to filter the outright league market
+ * @param leagues The league IDs to filter the outright league market
+ * @param fixtures The fixture IDs to filter the outright league market
+ * @param markets The IDs of the markets
+ * @returns GetOutrightLeagueMarketRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright league market from the API.
  */
 
 export class GetOutrightLeagueMarketRequestDto implements BaseEntity {
@@ -25,16 +24,16 @@ export class GetOutrightLeagueMarketRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-league-market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-league-market-request.dto.ts
@@ -25,15 +25,15 @@ export class GetOutrightLeagueMarketRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-leagues-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-leagues-request.dto.ts
@@ -23,15 +23,15 @@ export class GetOutrightLeaguesRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-leagues-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-leagues-request.dto.ts
@@ -1,19 +1,18 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetOutrightLeaguesRequestDto class for sending request
- * to get outright league from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
+ * to get outright leagues from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright leagues
+ * @param locations The location IDs to filter the outright leagues
+ * @param leagues The league IDs to filter the outright leagues
+ * @param fixtures The fixture IDs to filter the outright leagues
  * @returns GetOutrightLeaguesRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright leagues from the API.
  */
 export class GetOutrightLeaguesRequestDto implements BaseEntity {
   [key: string]: unknown;
@@ -23,16 +22,16 @@ export class GetOutrightLeaguesRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-livescore-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-livescore-request.dto.ts
@@ -24,15 +24,15 @@ export class GetOutrightLivescoreRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-livescore-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-livescore-request.dto.ts
@@ -1,19 +1,18 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetOutrightLivescoreRequestDto class for sending request
  * to get outright livescore from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright livescore
+ * @param locations The location IDs to filter the outright livescore
+ * @param fixtures The fixture IDs to filter the outright livescore
+ * @param tournaments The tournament IDs to filter the outright livescore
  * @returns GetOutrightLivescoreRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright livescore from the API.
  */
 
 export class GetOutrightLivescoreRequestDto implements BaseEntity {
@@ -24,16 +23,16 @@ export class GetOutrightLivescoreRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-market-request.dto.ts
@@ -1,20 +1,19 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetOutrightMarketRequestDto class for sending request
  * to get outright market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright market
+ * @param locations The location IDs to filter the outright market
+ * @param fixtures The fixture IDs to filter the outright market
+ * @param markets The IDs of the markets
+ * @param tournaments The tournament IDs to filter the outright market
  * @returns GetOutrightMarketRequestDto instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright market from the API.
  */
 
 export class GetOutrightMarketRequestDto implements BaseEntity {
@@ -25,16 +24,16 @@ export class GetOutrightMarketRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/outright-market-request.dto.ts
+++ b/src/api/common/snapshot/dtos/outright-market-request.dto.ts
@@ -25,15 +25,15 @@ export class GetOutrightMarketRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/snapshot-request.dto.ts
+++ b/src/api/common/snapshot/dtos/snapshot-request.dto.ts
@@ -1,18 +1,17 @@
-import { Expose, Type, Transform } from 'class-transformer';
-import moment, { Moment } from 'moment';
+import { Expose, Type } from 'class-transformer';
 import { BaseEntity } from '@entities';
 /**
  * GetSnapshotRequestDto class for sending request
- * to get snapshor from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
+ * to get snapshot from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the market
+ * @param locations The location IDs to filter the market
+ * @param leagues The league IDs to filter the market
+ * @param tournaments The tournament IDs to filter the market
+ * @param fixtures The fixture IDs to filter the market
+ * @param markets The IDs of the markets
  * @returns GetSnapshotRequestDto instance that
  * contains the properties for the request to get
  * market from the API.
@@ -25,16 +24,16 @@ export class GetSnapshotRequestDto implements BaseEntity {
   }
 
   @Expose({ name: 'Timestamp' })
-  @Transform((field) => moment(field.value))
-  timestamp!: Moment;
+  @Type(() => Number)
+  timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Transform((field) => moment(field.value))
-  fromDate!: Moment;
+  @Type(() => Number)
+  fromDate!: number;
 
   @Expose({ name: 'ToDate' })
-  @Transform((field) => moment(field.value))
-  toDate!: Moment;
+  @Type(() => Number)
+  toDate!: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/dtos/snapshot-request.dto.ts
+++ b/src/api/common/snapshot/dtos/snapshot-request.dto.ts
@@ -25,15 +25,15 @@ export class GetSnapshotRequestDto implements BaseEntity {
 
   @Expose({ name: 'Timestamp' })
   @Type(() => Number)
-  timestamp!: number;
+  timestamp?: number;
 
   @Expose({ name: 'FromDate' })
   @Type(() => Number)
-  fromDate!: number;
+  fromDate?: number;
 
   @Expose({ name: 'ToDate' })
   @Type(() => Number)
-  toDate!: number;
+  toDate?: number;
 
   @Expose({ name: 'Sports' })
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/event-request.ts
+++ b/src/api/common/snapshot/requests/event-request.ts
@@ -20,15 +20,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetEventRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/event-request.ts
+++ b/src/api/common/snapshot/requests/event-request.ts
@@ -7,13 +7,13 @@ import { HttpRequestDto } from '@api/common/dtos';
  * to get event from the API. It extends the
  * HttpRequestDto class and contains the properties
  * for the request to get event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the event
- * @param locationIds The location IDs to filter the event
- * @param leagueIds The league IDs to filter the event
- * @param fixtureIds The fixture IDs to filter the event
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the event
+ * @param locations The location IDs to filter the event
+ * @param leagues The league IDs to filter the event
+ * @param fixtures The fixture IDs to filter the event
  * @returns GetEventRequest instance that
  * contains the properties for the request to get
  * event from the API.
@@ -21,16 +21,16 @@ import { HttpRequestDto } from '@api/common/dtos';
 
 export class GetEventRequest extends HttpRequestDto {
   @Expose({ name: 'Timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Type(() => Number)
+  public timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Type(() => Number)
+  public fromDate?: number;
 
   @Expose({ name: 'ToDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/fixture-request.ts
+++ b/src/api/common/snapshot/requests/fixture-request.ts
@@ -7,30 +7,30 @@ import { HttpRequestDto } from '@api/common/dtos';
  * to get fixture from the API. It extends the
  * HttpRequestDto class and contains the properties
  * for the request to get fixture from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the fixture
- * @param locationIds The location IDs to filter the fixture
- * @param leagueIds The league IDs to filter the fixture
- * @param fixtureIds The fixture IDs to filter the fixture
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the fixture
+ * @param locations The location IDs to filter the fixture
+ * @param leagues The league IDs to filter the fixture
+ * @param fixtures The fixture IDs to filter the fixture
  * @returns GetFixtureRequest instance that
  * contains the properties for the request to get
  * fixture from the API.
  */
 
 export class GetFixtureRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/fixture-request.ts
+++ b/src/api/common/snapshot/requests/fixture-request.ts
@@ -20,15 +20,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetFixtureRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/inplay-event-request.ts
+++ b/src/api/common/snapshot/requests/inplay-event-request.ts
@@ -4,34 +4,34 @@ import { HttpRequestDto } from '@api/common/dtos';
 
 /**
  * GetInPlayEventRequest class for sending request
- * to get event from the API. It extends the
+ * to get inplay event from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the event
- * @param locationIds The location IDs to filter the event
- * @param leagueIds The league IDs to filter the event
- * @param fixtureIds The fixture IDs to filter the event
- * @param marketIds The IDs of the markets
+ * for the request to get inplay event from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the inplay event
+ * @param locations The location IDs to filter the inplay event
+ * @param leagues The league IDs to filter the inplay event
+ * @param fixtures The fixture IDs to filter the inplay event
+ * @param markets The IDs of the markets
  * @returns GetInPlayEventRequest instance that
  * contains the properties for the request to get
- * event from the API.
+ * inplay event from the API.
  */
 
 export class GetInPlayEventRequest extends HttpRequestDto {
   @Expose({ name: 'Timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Type(() => Number)
+  public timestamp!: number;
 
   @Expose({ name: 'FromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Type(() => Number)
+  public fromDate?: number;
 
   @Expose({ name: 'ToDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/inplay-event-request.ts
+++ b/src/api/common/snapshot/requests/inplay-event-request.ts
@@ -21,15 +21,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetInPlayEventRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/livescore-request.ts
+++ b/src/api/common/snapshot/requests/livescore-request.ts
@@ -3,34 +3,34 @@ import { Expose, Type } from 'class-transformer';
 import { HttpRequestDto } from '@api/common/dtos';
 
 /**
- * GetLiveScoreRequest class for sending request
+ * GetLivescoreRequest class for sending request
  * to get livescore from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get event from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the livescore
- * @param locationIds The location IDs to filter the livescore
- * @param leagueIds The league IDs to filter the livescore
- * @param fixtureIds The fixture IDs to filter the livescore
- * @returns GetLiveScoreRequest instance that
+ * for the request to get livescore from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the livescore
+ * @param locations The location IDs to filter the livescore
+ * @param leagues The league IDs to filter the livescore
+ * @param fixtures The fixture IDs to filter the livescore
+ * @returns GetLivescoreRequest instance that
  * contains the properties for the request to get
  * livescore from the API.
  */
 
 export class GetLivescoreRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/livescore-request.ts
+++ b/src/api/common/snapshot/requests/livescore-request.ts
@@ -20,15 +20,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetLivescoreRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/market-request.ts
+++ b/src/api/common/snapshot/requests/market-request.ts
@@ -7,30 +7,30 @@ import { HttpRequestDto } from '@api/common/dtos';
  * to get market from the API. It extends the
  * HttpRequestDto class and contains the properties
  * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the market
+ * @param locations The location IDs to filter the market
+ * @param leagues The league IDs to filter the market
+ * @param fixtures The fixture IDs to filter the market
  * @returns GetMarketRequest instance that
  * contains the properties for the request to get
  * market from the API.
  */
 
 export class GetMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/market-request.ts
+++ b/src/api/common/snapshot/requests/market-request.ts
@@ -20,15 +20,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-event-request.ts
+++ b/src/api/common/snapshot/requests/outright-event-request.ts
@@ -21,15 +21,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  * outright event from the API.
  */
 export class GetOutrightEventRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-event-request.ts
+++ b/src/api/common/snapshot/requests/outright-event-request.ts
@@ -6,32 +6,32 @@ import { HttpRequestDto } from '@api/common/dtos';
  * GetOutrightEventRequest class for sending request
  * to get outright event from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
- * @param tournamentsIds The IDs of the markets
+ * for the request to get outright event from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright event
+ * @param locations The location IDs to filter the outright event
+ * @param leagues The league IDs to filter the outright event
+ * @param fixtures The fixture IDs to filter the outright event
+ * @param markets The IDs of the markets
+ * @param tournaments The tournament IDs to filter the outright event
  * @returns GetOutrightEventRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright event from the API.
  */
 export class GetOutrightEventRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-fixture-request.ts
+++ b/src/api/common/snapshot/requests/outright-fixture-request.ts
@@ -21,15 +21,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetOutrightFixtureRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-fixture-request.ts
+++ b/src/api/common/snapshot/requests/outright-fixture-request.ts
@@ -6,31 +6,32 @@ import { HttpRequestDto } from '@api/common/dtos';
  * GetOutrightFixtureRequest class for sending request
  * to get outright fixture from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param tournamentsIds The IDs of the markets
+ * for the request to get outright fixture from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright fixture
+ * @param locations The location IDs to filter the outright fixture
+ * @param leagues The league IDs to filter the outright fixture
+ * @param fixtures The fixture IDs to filter the outright fixture
+ * @param tournaments The tournament IDs to filter the outright fixture
  * @returns GetOutrightFixtureRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright fixture from the API.
  */
 
 export class GetOutrightFixtureRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-league-market-request.ts
+++ b/src/api/common/snapshot/requests/outright-league-market-request.ts
@@ -21,15 +21,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetOutrightLeagueMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-league-market-request.ts
+++ b/src/api/common/snapshot/requests/outright-league-market-request.ts
@@ -6,32 +6,32 @@ import { HttpRequestDto } from '@api/common/dtos';
  * GetOutrightLeagueMarketRequest class for sending request
  * to get outright league market from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
+ * for the request to get outright league market from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright league market
+ * @param locations The location IDs to filter the outright league market
+ * @param leagues The league IDs to filter the outright league market
+ * @param fixtures The fixture IDs to filter the outright league market
+ * @param markets The IDs of the markets
  * @returns GetOutrightLeagueMarketRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright league market from the API.
  */
 
 export class GetOutrightLeagueMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-leagues-request.ts
+++ b/src/api/common/snapshot/requests/outright-leagues-request.ts
@@ -19,15 +19,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  * outright leagues from the API.
  */
 export class GetOutrightLeaguesRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-leagues-request.ts
+++ b/src/api/common/snapshot/requests/outright-leagues-request.ts
@@ -4,32 +4,32 @@ import { HttpRequestDto } from '@api/common/dtos';
 
 /**
  * GetOutrightLeaguesRequest class for sending request
- * to get outright league from the API. It extends the
+ * to get outright leagues from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param fixtureIds The fixture IDs to filter the market
+ * for the request to get outright leagues from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright leagues
+ * @param locations The location IDs to filter the outright leagues
+ * @param leagues The league IDs to filter the outright leagues
+ * @param fixtures The fixture IDs to filter the outright leagues
  * @returns GetOutrightLeaguesRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright leagues from the API.
  */
 export class GetOutrightLeaguesRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-livescore-request.ts
+++ b/src/api/common/snapshot/requests/outright-livescore-request.ts
@@ -6,31 +6,31 @@ import { HttpRequestDto } from '@api/common/dtos';
  * GetOutrightLivescoreRequest class for sending request
  * to get outright livescore from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
+ * for the request to get outright livescore from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright livescore
+ * @param locations The location IDs to filter the outright livescore
+ * @param fixtures The fixture IDs to filter the outright livescore
+ * @param tournaments The tournament IDs to filter the outright livescore
  * @returns GetOutrightLivescoreRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright livescore from the API.
  */
 
 export class GetOutrightLivescoreRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-livescore-request.ts
+++ b/src/api/common/snapshot/requests/outright-livescore-request.ts
@@ -20,15 +20,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetOutrightLivescoreRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/outright-market-request.ts
+++ b/src/api/common/snapshot/requests/outright-market-request.ts
@@ -6,32 +6,32 @@ import { HttpRequestDto } from '@api/common/dtos';
  * GetOutrightMarketRequest class for sending request
  * to get outright market from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
+ * for the request to get outright market from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the outright market
+ * @param locations The location IDs to filter the outright market
+ * @param tournaments The tournament IDs to filter the outright market
+ * @param fixtures The fixture IDs to filter the outright market
+ * @param markets The IDs of the markets
  * @returns GetOutrightMarketRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * outright market from the API.
  */
 
 export class GetOutrightMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)

--- a/src/api/common/snapshot/requests/outright-market-request.ts
+++ b/src/api/common/snapshot/requests/outright-market-request.ts
@@ -21,15 +21,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetOutrightMarketRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/snapshot-request.ts
+++ b/src/api/common/snapshot/requests/snapshot-request.ts
@@ -22,15 +22,15 @@ import { HttpRequestDto } from '@api/common/dtos';
  */
 
 export class GetSnapshotRequest extends HttpRequestDto {
-  @Expose({ name: 'Timestamp' })
+  @Expose()
   @Type(() => Number)
-  public timestamp!: number;
+  public timestamp?: number;
 
-  @Expose({ name: 'FromDate' })
+  @Expose()
   @Type(() => Number)
   public fromDate?: number;
 
-  @Expose({ name: 'ToDate' })
+  @Expose()
   @Type(() => Number)
   public toDate?: number;
 

--- a/src/api/common/snapshot/requests/snapshot-request.ts
+++ b/src/api/common/snapshot/requests/snapshot-request.ts
@@ -4,35 +4,35 @@ import { HttpRequestDto } from '@api/common/dtos';
 
 /**
  * GetSnapshotRequest class for sending request
- * to get snapshor from the API. It extends the
+ * to get snapshot from the API. It extends the
  * HttpRequestDto class and contains the properties
- * for the request to get market from the API.
- * @param timestamp The timestamp of the snapshot in UTC
- * @param fromDate The start date for the snapshot in UTC
- * @param toDate The end date for the snapshot in UTC
- * @param sportIds The sport IDs to filter the market
- * @param locationIds The location IDs to filter the market
- * @param leagueIds The league IDs to filter the market
- * @param tournamentsIds The IDs of the markets
- * @param fixtureIds The fixture IDs to filter the market
- * @param marketIds The IDs of the markets
- * @returns GetMarketRequest instance that
+ * for the request to get snapshot from the API.
+ * @param timestamp The Unix timestamp of the snapshot (seconds since epoch)
+ * @param fromDate The Unix timestamp for the start date of the snapshot (seconds since epoch)
+ * @param toDate The Unix timestamp for the end date of the snapshot (seconds since epoch)
+ * @param sports The sport IDs to filter the snapshot
+ * @param locations The location IDs to filter the snapshot
+ * @param leagues The league IDs to filter the snapshot
+ * @param fixtures The fixture IDs to filter the snapshot
+ * @param markets The IDs of the markets to filter the snapshot
+ * @param tournaments The tournament IDs to filter the snapshot
+ * @returns GetSnapshotRequest instance that
  * contains the properties for the request to get
- * market from the API.
+ * snapshot from the API.
  */
 
 export class GetSnapshotRequest extends HttpRequestDto {
-  @Expose({ name: 'timestamp' })
-  @Type(() => Date)
-  public timestamp!: Date;
+  @Expose({ name: 'Timestamp' })
+  @Type(() => Number)
+  public timestamp!: number;
 
-  @Expose({ name: 'fromDate' })
-  @Type(() => Date)
-  public fromDate?: Date;
+  @Expose({ name: 'FromDate' })
+  @Type(() => Number)
+  public fromDate?: number;
 
-  @Expose({ name: 'toDate' })
-  @Type(() => Date)
-  public toDate?: Date;
+  @Expose({ name: 'ToDate' })
+  @Type(() => Number)
+  public toDate?: number;
 
   @Expose()
   @Type(() => Number)


### PR DESCRIPTION
changed Request/DTO's 
- change date fields from moment to number
- timestamp / fromDate / toDate members to optional
-  changed the Expose({name: ...}) to bare Expose() with no name, as it caused the loss of data in conversion from the DTO.