### PR TITLE
Add new fields for livescore and fixture

### DIFF
--- a/src/entities/core-entities/enums/incident-confirmation.ts
+++ b/src/entities/core-entities/enums/incident-confirmation.ts
@@ -1,0 +1,5 @@
+export enum IncidentConfirmation {
+  Confirmed = 0,
+  TBD = 1,
+  Cancelled = 2
+}

--- a/src/entities/core-entities/enums/index.ts
+++ b/src/entities/core-entities/enums/index.ts
@@ -13,3 +13,4 @@ export * from './subscription-state';
 export * from './danger-indicator-status';
 export * from './danger-indicator-type';
 export * from './clock-status';
+export * from './incident-confirmation';

--- a/src/entities/core-entities/livescore/current-incident.ts
+++ b/src/entities/core-entities/livescore/current-incident.ts
@@ -1,5 +1,7 @@
 import { Expose, Type } from 'class-transformer';
 
+import { IncidentConfirmation } from '@lsports/enums';
+
 export class CurrentIncident {
   @Expose({ name: 'Id' })
   id?: number;
@@ -10,4 +12,7 @@ export class CurrentIncident {
   @Expose({ name: 'LastUpdate' })
   @Type(() => Date)
   lastUpdate?: Date;
+
+  @Expose({ name: 'Confirmation' })
+  confirmation?: IncidentConfirmation;
 }

--- a/test/entities/core-entities/enums/incident-confirmation.spec.ts
+++ b/test/entities/core-entities/enums/incident-confirmation.spec.ts
@@ -1,0 +1,20 @@
+import { IncidentConfirmation } from '../../../../src/entities/core-entities/enums/incident-confirmation';
+
+describe('IncidentConfirmation Enum', () => {
+  it('should map names to values correctly', () => {
+    expect(IncidentConfirmation.Confirmed).toBe(0);
+    expect(IncidentConfirmation.TBD).toBe(1);
+    expect(IncidentConfirmation.Cancelled).toBe(2);
+  });
+
+  it('should map values to names correctly (reverse mapping)', () => {
+    expect(IncidentConfirmation[0]).toBe('Confirmed');
+    expect(IncidentConfirmation[1]).toBe('TBD');
+    expect(IncidentConfirmation[2]).toBe('Cancelled');
+  });
+
+  it('should contain all expected enum keys', () => {
+    const keys = Object.keys(IncidentConfirmation).filter((k) => isNaN(Number(k)));
+    expect(keys).toEqual(['Confirmed', 'TBD', 'Cancelled']);
+  });
+});

--- a/test/entities/core-entities/livescore/current-incident.spec.ts
+++ b/test/entities/core-entities/livescore/current-incident.spec.ts
@@ -1,5 +1,6 @@
 import { plainToInstance } from 'class-transformer';
 import { CurrentIncident } from '../../../../src/entities/core-entities/livescore/current-incident';
+import { IncidentConfirmation } from '../../../../src/entities/core-entities/enums/incident-confirmation';
 
 describe('CurrentIncident Entity', () => {
   it('should deserialize a plain object into a CurrentIncident instance', (): void => {
@@ -7,6 +8,7 @@ describe('CurrentIncident Entity', () => {
       Id: 1,
       Name: 'Incident1',
       LastUpdate: '2024-06-01T12:00:00Z',
+      Confirmation: IncidentConfirmation.Confirmed,
     };
     const incident = plainToInstance(CurrentIncident, plain, { excludeExtraneousValues: true });
     expect(incident).toBeInstanceOf(CurrentIncident);
@@ -14,6 +16,7 @@ describe('CurrentIncident Entity', () => {
     expect(incident.name).toBe('Incident1');
     expect(incident.lastUpdate).toBeInstanceOf(Date);
     expect(incident.lastUpdate?.toISOString()).toBe('2024-06-01T12:00:00.000Z');
+    expect(incident.confirmation).toBe(IncidentConfirmation.Confirmed);
   });
 
   it('should handle missing properties', (): void => {
@@ -22,6 +25,33 @@ describe('CurrentIncident Entity', () => {
     expect(incident.id).toBeUndefined();
     expect(incident.name).toBeUndefined();
     expect(incident.lastUpdate).toBeUndefined();
+    expect(incident.confirmation).toBeUndefined();
+  });
+
+  it('should handle different confirmation enum values', (): void => {
+    const plainConfirmed = {
+      Id: 2,
+      Name: 'Confirmed Incident',
+      Confirmation: IncidentConfirmation.Confirmed,
+    };
+    const plainTBD = {
+      Id: 3,
+      Name: 'TBD Incident',
+      Confirmation: IncidentConfirmation.TBD,
+    };
+    const plainCancelled = {
+      Id: 4,
+      Name: 'Cancelled Incident',
+      Confirmation: IncidentConfirmation.Cancelled,
+    };
+
+    const confirmedIncident = plainToInstance(CurrentIncident, plainConfirmed, { excludeExtraneousValues: true });
+    const tbdIncident = plainToInstance(CurrentIncident, plainTBD, { excludeExtraneousValues: true });
+    const cancelledIncident = plainToInstance(CurrentIncident, plainCancelled, { excludeExtraneousValues: true });
+
+    expect(confirmedIncident.confirmation).toBe(IncidentConfirmation.Confirmed);
+    expect(tbdIncident.confirmation).toBe(IncidentConfirmation.TBD);
+    expect(cancelledIncident.confirmation).toBe(IncidentConfirmation.Cancelled);
   });
 
   it('should ignore extraneous properties', (): void => {


### PR DESCRIPTION
- Introduced IncidentConfirmation enum with values: Confirmed, TBD, and Cancelled.
- Updated CurrentIncident class to include a confirmation property of type IncidentConfirmation.
- Added tests for IncidentConfirmation enum and its integration within CurrentIncident entity.