### PR TITLE
Update REST API base URL for trade360

### DIFF
--- a/sample/customer-api-sample/src/config/app-config.json
+++ b/sample/customer-api-sample/src/config/app-config.json
@@ -1,6 +1,6 @@
 {
   "trade360": {
-    "restApiBaseUrl": "https://stm-api.qa.lsports.cloud/",
+    "restApiBaseUrl": "https://stm-api.lsports.eu/",
     "inPlayMQSettings": {
       "username": "LSPORTS_USERNAME",
       "password": "LSPORTS_PASSWORD",


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Updates the <code>trade360</code> REST API base URL in the application configuration to point to the production environment. Ensures that the <code>customer-api-sample</code> connects to the correct endpoint for trade operations.


<details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Refactor-API-response-...</td><td>January 20, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/91?tool=ast>(Baz)</a>.