### PR TITLE
TR-22130: Fix missing Snapshot API DTOs export

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.8.2](#version-382)
 - [Version 3.8.1](#version-381)
 - [Version 3.8.0](#version-380)
 - [Version 3.7.3](#version-373)
@@ -19,6 +20,18 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.8.2
+
+### Bug Fixes
+
+- **Fixed missing Snapshot API DTOs export** - Added missing export of Snapshot DTOs (`GetFixtureRequestDto`, `GetLivescoreRequestDto`, `GetMarketRequestDto`, `GetInPlayEventRequestDto`, `GetEventRequestDto`, `GetOutrightEventRequestDto`, `GetOutrightFixtureRequestDto`, `GetOutrightLeaguesRequestDto`, `GetOutrightLeagueMarketRequestDto`, `GetOutrightLeagueEventsRequestDto`, `GetOutrightLivescoreRequestDto`, `GetOutrightMarketRequestDto`) from the SDK package. Previously, these DTOs were not accessible when installing the SDK via npm, preventing users from using the Snapshot API functionality.
+
+### Technical Details
+
+- Added `export * from '../common/snapshot/dtos'` to `src/api/snapshot-api/index.ts`
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.8.0",
+  "version": "3.8.2",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.8.0",
+      "version": "3.8.2",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.8.1",
+  "version": "3.8.2",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/api/snapshot-api/index.ts
+++ b/src/api/snapshot-api/index.ts
@@ -1,3 +1,4 @@
+export * from '../common/snapshot/dtos';
 export * from '../common/snapshot/requests';
 export * from '../common/snapshot/responses';
 export * from './snapshot-api';


### PR DESCRIPTION
# User description
- Added export for snapshot DTOs from src/api/snapshot-api/index.ts
- Fixes issue where GetFixtureRequestDto and other snapshot DTOs were not accessible when installing SDK via npm
- Bumped version to 3.8.2

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolves the accessibility issue of Snapshot API DTOs by exporting them from the <code>snapshot-api</code> module. Ensures that essential request objects like <code>GetFixtureRequestDto</code> are available to SDK consumers for interacting with the Snapshot service.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/92?tool=ast&topic=Release+Management>Release Management</a>
        </td><td>Bumps the SDK version to 3.8.2 and updates the <code>CHANGELOG.md</code> to reflect the bug fix.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Release-version-3.8.1-...</td><td>January 05, 2026</td></tr>
<tr><td>PavelTemno</td><td>enhance-league-fixture...</td><td>December 28, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/92?tool=ast&topic=Snapshot+API+Fix>Snapshot API Fix</a>
        </td><td>Exports missing DTOs from the <code>snapshot-api</code> module to enable the use of Snapshot API functionality.<details><summary>Modified files (1)</summary><ul><li>src/api/snapshot-api/index.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fixing-spaces</td><td>January 14, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/92?tool=ast>(Baz)</a>.