### PR TITLE
TR-22139: Fix response transformation returning PascalCase instead of…

### DIFF
--- a/src/api/base-http-client/base-http-client.ts
+++ b/src/api/base-http-client/base-http-client.ts
@@ -119,8 +119,8 @@ export abstract class BaseHttpClient {
    * @param httpResponse The response received from the API call
    * @param responsePayloadDto The response payload DTO to be used
    * for transforming the response
-   * @returns The response payload DTO with the required properties
-   * serialized to PascalCase format (API format)
+   * @returns The response payload DTO body with properties in camelCase
+   * format as defined by the TypeScript class decorators
    * @throws HttpResponseError if the response does not contain the
    * required properties
    */
@@ -134,11 +134,8 @@ export abstract class BaseHttpClient {
 
     this.validateResponsePayloadStructure(responsePayload);
 
-    // Serialize the response body back to PascalCase format (API format)
-    const serializedBody = TransformerUtil.serializeToApiFormat(responsePayload.body);
-
-    // Return the serialized object as TResponse (maintains type compatibility)
-    return serializedBody as TResponse;
+    // Return the transformed body directly (camelCase format matching TypeScript types)
+    return responsePayload.body;
   }
 
   /**


### PR DESCRIPTION
# User description
… camelCase

The handleValidResponse method was incorrectly calling serializeToApiFormat() which converted the response body back to PascalCase (e.g., 'Sports' instead of 'sports'). This caused properties like sportsCollection.sports to return undefined even when the data was present.

Fixed by returning responsePayload.body directly instead of serializing it back to API format.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Fixes a bug in the response transformation logic by ensuring the SDK returns data in camelCase format to match TypeScript definitions. Modifies the <code>BaseHttpClient</code> to return the <code>responsePayload.body</code> directly, preventing incorrect re-serialization to PascalCase.


<details><summary>Latest Contributors(0)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/93?tool=ast>(Baz)</a>.