### PR TITLE
Release version 3.8.3: Fix API response transformation to return came…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.8.3](#version-383)
 - [Version 3.8.2](#version-382)
 - [Version 3.8.1](#version-381)
 - [Version 3.8.0](#version-380)
@@ -20,6 +21,29 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.8.3
+
+### Bug Fixes
+
+- **Fixed API Response Transformation Returning Wrong Property Names**
+  - **Issue:** API response properties were returning `undefined` even when data was present (e.g., `sportsCollection.sports` returned `undefined`)
+  - **Root Cause:** The `handleValidResponse` method was calling `serializeToApiFormat()` which converted the response body back to PascalCase format (e.g., `Sports` instead of `sports`), causing a mismatch with TypeScript type definitions
+  - **Fix:** Removed the `serializeToApiFormat()` call and now returns `responsePayload.body` directly, preserving camelCase property names as defined by the `@Expose` decorators
+  - **Files Changed:**
+    - `src/api/base-http-client/base-http-client.ts`
+  - **Impact:** All API responses now correctly return camelCase properties matching TypeScript types. Properties like `locations`, `sports`, `leagues`, `markets` and nested properties like `location.id`, `location.name` now work as expected.
+
+### Technical Details
+
+- The `@Expose({ name: 'Sports' })` decorator is designed to transform API responses from PascalCase (`Sports`) to camelCase (`sports`) for TypeScript usage
+- The `serializeToApiFormat` function should only be used when sending data TO the API, not when returning data FROM the API
+
+### Backward Compatibility
+
+All changes are backward compatible. This fix restores the expected behavior where API responses use camelCase property names matching the TypeScript type definitions.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.8.2",
+  "version": "3.8.3",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
# User description
…lCase property names. Resolved issue where properties returned undefined due to incorrect serialization. Updated CHANGELOG and bumped version in package.json.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Corrects the API response transformation within the <code>BaseHttpClient</code> to ensure property names are returned in camelCase as expected by TypeScript definitions. Resolves a bug where response data appeared as <code>undefined</code> due to incorrect PascalCase serialization during the response handling flow.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TR-22130-Fix-missing-S...</td><td>January 21, 2026</td></tr>
<tr><td>PavelTemno</td><td>enhance-league-fixture...</td><td>December 28, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/94?tool=ast>(Baz)</a>.