### PR TITLE
Added sportid logging

### DIFF
--- a/sample/feed-sample/src/handler/inplay/fixture-metadata-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/fixture-metadata-update.handler.ts
@@ -7,6 +7,7 @@ export class FixtureMetadataUpdateHandler implements IEntityHandler<FixtureMetad
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/livescore-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/livescore-update.handler.ts
@@ -7,6 +7,7 @@ export class LivescoreUpdateHandler implements IEntityHandler<LivescoreUpdate> {
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/market-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/market-update.handler.ts
@@ -7,6 +7,7 @@ export class MarketUpdateHandler implements IEntityHandler<MarketUpdate> {
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/outright-league-fixture-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/outright-league-fixture-update.handler.ts
@@ -17,6 +17,7 @@ export class OutrightLeagueFixtureUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/outright-league-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/outright-league-market-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/outright-league-settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/outright-league-settlement-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueSettlementUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/settlement-update.handler.ts
@@ -7,6 +7,7 @@ export class SettlementUpdateHandler implements IEntityHandler<SettlementUpdate>
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/ouright-settlements-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/ouright-settlements-update.handler.ts
@@ -11,6 +11,7 @@ export class OutrightSettlementsUpdateHandler implements IEntityHandler<Outright
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-fixture-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-fixture-market-update.handler.ts
@@ -17,6 +17,7 @@ export class OutrightFixtureMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-fixture-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-fixture-update.handler.ts
@@ -7,6 +7,7 @@ export class OutrightFixtureUpdateHandler implements IEntityHandler<OutrightFixt
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-league-fixture-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-league-fixture-update.handler.ts
@@ -17,6 +17,7 @@ export class OutrightLeagueFixtureUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-league-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-league-market-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-league-settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-league-settlement-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueSettlementUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-score-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-score-update.handler.ts
@@ -7,6 +7,7 @@ export class OutrightScoreUpdateHandler implements IEntityHandler<OutrightScoreU
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      sportId: transportHeaders.sportId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
```mermaid
graph LR
OutrightScoreUpdateHandler_processAsync_("OutrightScoreUpdateHandler.processAsync"):::modified
TRANSPORT_HEADERS_("TRANSPORT_HEADERS"):::modified
OutrightLeagueFixtureUpdateHandler_processAsync_("OutrightLeagueFixtureUpdateHandler.processAsync"):::modified
OutrightFixtureMarketUpdateHandler_processAsync_("OutrightFixtureMarketUpdateHandler.processAsync"):::modified
OutrightSettlementsUpdateHandler_processAsync_("OutrightSettlementsUpdateHandler.processAsync"):::modified
MarketUpdateHandler_processAsync_("MarketUpdateHandler.processAsync"):::modified
LivescoreUpdateHandler_processAsync_("LivescoreUpdateHandler.processAsync"):::modified
FixtureMetadataUpdateHandler_processAsync_("FixtureMetadataUpdateHandler.processAsync"):::modified
OutrightScoreUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
OutrightLeagueFixtureUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
OutrightFixtureMarketUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
OutrightSettlementsUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
MarketUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
LivescoreUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
FixtureMetadataUpdateHandler_processAsync_ -- "Adds sportId to outbound metadata, enabling sport-aware processing." --> TRANSPORT_HEADERS_
classDef added stroke:#15AA7A
classDef removed stroke:#CD5270
classDef modified stroke:#EDAC4C
linkStyle default stroke:#CBD5E1,font-size:13px
```

Enhance the logging of message metadata by including the <code>sportId</code> in various feed handlers. This change affects multiple entity handlers responsible for processing inplay and prematch updates, ensuring better traceability of sport-specific data.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Release-version-3.7.3-...</td><td>December 25, 2025</td></tr>
<tr><td>noam.m@lsports.eu</td><td>Feature-tr-18311-expos...</td><td>August 27, 2025</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/97?tool=ast>(Baz)</a>.