### PR TITLE
fix outright fixture and outright league fixture add missing fields

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.0](#version-390)
 - [Version 3.8.3](#version-383)
 - [Version 3.8.2](#version-382)
 - [Version 3.8.1](#version-381)
@@ -21,6 +22,47 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.0
+
+Adds FixtureName, Season, and enhanced participant fields to outright entities and snapshot responses for improved fixture metadata support.
+
+### New Features
+
+- **Enhanced Outright Fixture Entities**
+  - Added `fixtureName` property (optional string) to `OutrightFixture` for fixture name information
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixture` for season information
+
+- **Enhanced Outright League Fixture Entities**
+  - Added `fixtureName` property (optional string) to `OutrightLeagueFixture` for fixture name information
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixture` for season information
+
+- **Enhanced Outright Participant Entities**
+  - Added `form` property (optional string) to `OutrightParticipant` for recent form (e.g., "WWDLW")
+  - Added `formation` property (optional string) to `OutrightParticipant` for tactical formation (e.g., "4-3-3")
+  - Added `fixturePlayers` property (optional `FixturePlayer[]`) to `OutrightParticipant` for player lineup information
+  - Added `gender` property (optional number) to `OutrightParticipant`
+  - Added `ageCategory` property (optional number) to `OutrightParticipant`
+  - Added `type` property (optional number) to `OutrightParticipant`
+
+- **Enhanced Outright Fixture Snapshot Response**
+  - Added `fixtureName` property (optional string) to `OutrightFixtureBodyStructure`
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixtureBodyStructure`
+
+- **Enhanced Outright League Fixture Snapshot Response**
+  - Added `fixtureName` property (optional string) to `OutrightLeagueFixtureSnapshot`
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixtureSnapshot`
+
+### Testing
+
+- Added comprehensive unit tests for all new properties
+- Tests cover serialization/deserialization and nullable scenarios
+
+### Backward Compatibility
+
+All changes are backward compatible. Existing code will continue to work without modification. The new properties are optional additions to existing entities, ensuring consistency between feed and snapshot response entities.
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ All notable changes to this project will be documented in this file.
 ## Table of Contents
 
 - [Version 3.9.1](#version-391)
-- [Version 3.9.0](#version-390)
 - [Version 3.8.3](#version-383)
 - [Version 3.8.2](#version-382)
 - [Version 3.8.1](#version-381)
@@ -59,41 +58,6 @@ Adds FixtureName, Season, and enhanced participant fields to outright entities a
 ### Testing
 
 - Added comprehensive unit tests for all new properties
-
----
-
-## Version 3.9.0
-
-### New Features
-
-- **Enhanced Outright Fixture Entities**
-  - Added `fixtureName` property (optional string) to `OutrightFixture` for fixture name information
-  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixture` for season information
-
-- **Enhanced Outright League Fixture Entities**
-  - Added `fixtureName` property (optional string) to `OutrightLeagueFixture` for fixture name information
-  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixture` for season information
-
-- **Enhanced Outright Participant Entities**
-  - Added `form` property (optional string) to `OutrightParticipant` for recent form (e.g., "WWDLW")
-  - Added `formation` property (optional string) to `OutrightParticipant` for tactical formation (e.g., "4-3-3")
-  - Added `fixturePlayers` property (optional `FixturePlayer[]`) to `OutrightParticipant` for player lineup information
-  - Added `gender` property (optional number) to `OutrightParticipant`
-  - Added `ageCategory` property (optional number) to `OutrightParticipant`
-  - Added `type` property (optional number) to `OutrightParticipant`
-
-- **Enhanced Outright Fixture Snapshot Response**
-  - Added `fixtureName` property (optional string) to `OutrightFixtureBodyStructure`
-  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixtureBodyStructure`
-
-- **Enhanced Outright League Fixture Snapshot Response**
-  - Added `fixtureName` property (optional string) to `OutrightLeagueFixtureSnapshot`
-  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixtureSnapshot`
-
-### Testing
-
-- Added comprehensive unit tests for all new properties
-- Tests cover serialization/deserialization and nullable scenarios
 
 ### Backward Compatibility
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.1](#version-391)
 - [Version 3.9.0](#version-390)
 - [Version 3.8.3](#version-383)
 - [Version 3.8.2](#version-382)
@@ -25,9 +26,43 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## Version 3.9.0
+## Version 3.9.1
 
 Adds FixtureName, Season, and enhanced participant fields to outright entities and snapshot responses for improved fixture metadata support.
+
+### New Features
+
+- **Enhanced Outright Fixture Entities**
+  - Added `fixtureName` property (optional string) to `OutrightFixture` for fixture name information
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixture` for season information
+
+- **Enhanced Outright League Fixture Entities**
+  - Added `fixtureName` property (optional string) to `OutrightLeagueFixture` for fixture name information
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixture` for season information
+
+- **Enhanced Outright Participant Entities**
+  - Added `form` property (optional string) to `OutrightParticipant` for recent form (e.g., "WWDLW")
+  - Added `formation` property (optional string) to `OutrightParticipant` for tactical formation (e.g., "4-3-3")
+  - Added `fixturePlayers` property (optional `FixturePlayer[]`) to `OutrightParticipant` for player lineup information
+  - Added `gender` property (optional number) to `OutrightParticipant`
+  - Added `ageCategory` property (optional number) to `OutrightParticipant`
+  - Added `type` property (optional number) to `OutrightParticipant`
+
+- **Enhanced Outright Fixture Snapshot Response**
+  - Added `fixtureName` property (optional string) to `OutrightFixtureBodyStructure`
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightFixtureBodyStructure`
+
+- **Enhanced Outright League Fixture Snapshot Response**
+  - Added `fixtureName` property (optional string) to `OutrightLeagueFixtureSnapshot`
+  - Added `season` property (optional `IdNNameRecord`) to `OutrightLeagueFixtureSnapshot`
+
+### Testing
+
+- Added comprehensive unit tests for all new properties
+
+---
+
+## Version 3.9.0
 
 ### New Features
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.9.0",
+      "version": "3.9.1",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.0",
+  "version": "3.9.1",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/sample/feed-sample/package-lock.json
+++ b/sample/feed-sample/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "feed-sample",
-  "version": "2.1.1",
+  "version": "2.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "feed-sample",
-      "version": "2.1.1",
+      "version": "2.2.0",
       "license": "ISC",
       "dependencies": {
         "bunyan": "^1.8.15",
@@ -23,7 +23,7 @@
       }
     },
     "../..": {
-      "version": "3.8.0",
+      "version": "3.9.0",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/src/api/common/body-entities/responses/outright-fixture-body-structure.ts
+++ b/src/api/common/body-entities/responses/outright-fixture-body-structure.ts
@@ -3,7 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { SportsBodyStructure } from './sports-body-structure';
 import { LocationsBodyStructure } from './locations-body-structure';
 import { ParticipantSchedule } from './participant-schedule';
-import { Subscription } from '@lsports/entities/common';
+import { IdNNameRecord, Subscription } from '@lsports/entities/common';
 import { FixtureVenue } from '@lsports/entities';
 
 /**
@@ -12,6 +12,9 @@ import { FixtureVenue } from '@lsports/entities';
  * outright fixture element structure.
  */
 export class OutrightFixtureBodyStructure {
+  @Expose({ name: 'FixtureName' })
+  public fixtureName?: string;
+
   @Expose({ name: 'Sport' })
   @Type(() => SportsBodyStructure)
   sport!: SportsBodyStructure;
@@ -40,4 +43,8 @@ export class OutrightFixtureBodyStructure {
   @Expose({ name: 'Venue' })
   @Type(() => FixtureVenue)
   public venue?: FixtureVenue;
+
+  @Expose({ name: 'Season' })
+  @Type(() => IdNNameRecord)
+  public season?: IdNNameRecord;
 }

--- a/src/api/common/body-entities/responses/outright-league-fixture-snapshot.ts
+++ b/src/api/common/body-entities/responses/outright-league-fixture-snapshot.ts
@@ -2,7 +2,7 @@ import { Expose, Type } from 'class-transformer';
 
 import { SportsBodyStructure } from './sports-body-structure';
 import { LocationsBodyStructure } from './locations-body-structure';
-import { NameValueRecord, Subscription } from '@lsports/entities/common';
+import { IdNNameRecord, NameValueRecord, Subscription } from '@lsports/entities/common';
 
 /**
  * Outright League Fixture Snapshot class is responsible for
@@ -10,6 +10,9 @@ import { NameValueRecord, Subscription } from '@lsports/entities/common';
  * outright league fixture structure.
  */
 export class OutrightLeagueFixtureSnapshot {
+  @Expose({ name: 'FixtureName' })
+  public fixtureName?: string;
+
   @Expose({ name: 'Subscription' })
   @Type(() => Subscription)
   subscription!: Subscription;
@@ -36,4 +39,8 @@ export class OutrightLeagueFixtureSnapshot {
   @Expose({ name: 'EndDate' })
   @Type(() => Date)
   endDate?: Date;
+
+  @Expose({ name: 'Season' })
+  @Type(() => IdNNameRecord)
+  public season?: IdNNameRecord;
 }

--- a/src/entities/core-entities/outright-league/outright-league-fixture.ts
+++ b/src/entities/core-entities/outright-league/outright-league-fixture.ts
@@ -2,9 +2,12 @@ import { Expose, Type } from 'class-transformer';
 
 import { Location, Sport } from '@lsports/entities';
 import { FixtureStatus } from '@lsports/enums';
-import { NameValueRecord, Subscription } from '@lsports/entities/common';
+import { IdNNameRecord, NameValueRecord, Subscription } from '@lsports/entities/common';
 
 export class OutrightLeagueFixture {
+  @Expose({ name: 'FixtureName' })
+  public fixtureName?: string;
+
   @Expose({ name: 'Subscription' })
   @Type(() => Subscription)
   subscription?: Subscription;
@@ -31,4 +34,8 @@ export class OutrightLeagueFixture {
   @Expose({ name: 'EndDate' })
   @Type(() => Date)
   endDate?: Date;
+
+  @Expose({ name: 'Season' })
+  @Type(() => IdNNameRecord)
+  public season?: IdNNameRecord;
 }

--- a/src/entities/core-entities/outright-sport/outright-fixture.ts
+++ b/src/entities/core-entities/outright-sport/outright-fixture.ts
@@ -1,11 +1,14 @@
 import { Expose, Type } from 'class-transformer';
 
 import { Sport, Location, FixtureVenue } from '@lsports/entities';
-import { NameValueRecord, Subscription } from '@lsports/entities/common';
+import { IdNNameRecord, NameValueRecord, Subscription } from '@lsports/entities/common';
 
 import { OutrightParticipant } from './outright-participant';
 
 export class OutrightFixture {
+  @Expose({ name: 'FixtureName' })
+  public fixtureName?: string;
+
   @Expose({ name: 'Subscription' })
   @Type(() => Subscription)
   subscription?: Subscription;
@@ -40,4 +43,8 @@ export class OutrightFixture {
   @Expose({ name: 'Venue' })
   @Type(() => FixtureVenue)
   public venue?: FixtureVenue;
+
+  @Expose({ name: 'Season' })
+  @Type(() => IdNNameRecord)
+  public season?: IdNNameRecord;
 }

--- a/src/entities/core-entities/outright-sport/outright-participant.ts
+++ b/src/entities/core-entities/outright-sport/outright-participant.ts
@@ -2,6 +2,7 @@ import { Expose, Type } from 'class-transformer';
 
 import { ActiveParticipant } from '@lsports/enums';
 import { NameValueRecord } from '@lsports/entities/common';
+import { FixturePlayer } from '../fixture/fixture-player';
 
 export class OutrightParticipant {
   @Expose({ name: 'Id' })
@@ -18,6 +19,25 @@ export class OutrightParticipant {
 
   @Expose({ name: 'IsActive' })
   isActive?: ActiveParticipant;
+
+  @Expose({ name: 'Form' })
+  public form?: string;
+
+  @Expose({ name: 'Formation' })
+  public formation?: string;
+
+  @Expose({ name: 'FixturePlayers' })
+  @Type(() => FixturePlayer)
+  public fixturePlayers?: FixturePlayer[];
+
+  @Expose({ name: 'Gender' })
+  public gender?: number;
+
+  @Expose({ name: 'AgeCategory' })
+  public ageCategory?: number;
+
+  @Expose({ name: 'Type' })
+  public type?: number;
 
   @Expose({ name: 'ExtraData' })
   @Type(() => NameValueRecord)

--- a/test/api/common/body-entities/responses/outright-fixture-body-structure.spec.ts
+++ b/test/api/common/body-entities/responses/outright-fixture-body-structure.spec.ts
@@ -1,0 +1,85 @@
+import { plainToInstance } from 'class-transformer';
+import { OutrightFixtureBodyStructure } from '../../../../../src/api/common/body-entities/responses/outright-fixture-body-structure';
+import { Subscription } from '../../../../../src/entities/core-entities/common/subscription';
+import { IdNNameRecord } from '../../../../../src/entities/core-entities/common/id-and-name-record';
+
+describe('OutrightFixtureBodyStructure', () => {
+  it('should deserialize a plain object into an OutrightFixtureBodyStructure instance', (): void => {
+    const plain = {
+      FixtureName: 'World Cup 2024',
+      Sport: { Id: 1, Name: 'Football' },
+      Location: { Id: 10, Name: 'Europe' },
+      StartDate: '2024-06-01T12:00:00Z',
+      LastUpdate: '2024-06-01T13:00:00Z',
+      Status: 1,
+      Participants: [{ Id: 100, Name: 'Team A' }],
+      Subscription: { Type: 1, Status: 'Active' },
+      Venue: { Id: 1, Name: 'Stadium' },
+      Season: { Id: 2024, Name: '2024-2025' },
+    };
+    const fixture = plainToInstance(OutrightFixtureBodyStructure, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture).toBeInstanceOf(OutrightFixtureBodyStructure);
+    expect(fixture.fixtureName).toBe('World Cup 2024');
+    expect(fixture.sport).toBeDefined();
+    expect(fixture.location).toBeDefined();
+    expect(fixture.subscription).toBeInstanceOf(Subscription);
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2024);
+    expect(fixture.season?.name).toBe('2024-2025');
+  });
+
+  it('should handle missing FixtureName and Season properties', (): void => {
+    const plain = {
+      Sport: { Id: 1, Name: 'Football' },
+      Location: { Id: 10, Name: 'Europe' },
+      StartDate: '2024-06-01T12:00:00Z',
+      LastUpdate: '2024-06-01T13:00:00Z',
+      Status: 1,
+      Participants: [],
+      Subscription: { Type: 1, Status: 'Active' },
+    };
+    const fixture = plainToInstance(OutrightFixtureBodyStructure, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture.fixtureName).toBeUndefined();
+    expect(fixture.season).toBeUndefined();
+  });
+
+  it('should deserialize FixtureName property correctly', (): void => {
+    const plain = {
+      FixtureName: 'Champions League Final',
+      Sport: { Id: 1, Name: 'Football' },
+      Location: { Id: 10, Name: 'Europe' },
+      StartDate: '2024-06-01T12:00:00Z',
+      LastUpdate: '2024-06-01T13:00:00Z',
+      Status: 1,
+      Participants: [],
+      Subscription: { Type: 1, Status: 'Active' },
+    };
+    const fixture = plainToInstance(OutrightFixtureBodyStructure, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture.fixtureName).toBe('Champions League Final');
+  });
+
+  it('should deserialize Season property correctly', (): void => {
+    const plain = {
+      Sport: { Id: 1, Name: 'Football' },
+      Location: { Id: 10, Name: 'Europe' },
+      StartDate: '2024-06-01T12:00:00Z',
+      LastUpdate: '2024-06-01T13:00:00Z',
+      Status: 1,
+      Participants: [],
+      Subscription: { Type: 1, Status: 'Active' },
+      Season: { Id: 2025, Name: '2025-2026' },
+    };
+    const fixture = plainToInstance(OutrightFixtureBodyStructure, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2025);
+    expect(fixture.season?.name).toBe('2025-2026');
+  });
+});

--- a/test/api/common/body-entities/responses/outright-league-fixture-snapshot.spec.ts
+++ b/test/api/common/body-entities/responses/outright-league-fixture-snapshot.spec.ts
@@ -2,12 +2,14 @@ import { plainToInstance } from 'class-transformer';
 import { OutrightLeagueFixtureSnapshot } from '../../../../../src/api/common/body-entities/responses/outright-league-fixture-snapshot';
 import { Subscription } from '../../../../../src/entities/core-entities/common/subscription';
 import { NameValueRecord } from '../../../../../src/entities/core-entities/common/name-value-record';
+import { IdNNameRecord } from '../../../../../src/entities/core-entities/common/id-and-name-record';
 import { SportsBodyStructure } from '../../../../../src/api/common/body-entities/responses/sports-body-structure';
 import { LocationsBodyStructure } from '../../../../../src/api/common/body-entities/responses/locations-body-structure';
 
 describe('OutrightLeagueFixtureSnapshot', () => {
   it('should deserialize a plain object into an OutrightLeagueFixtureSnapshot instance with all properties including EndDate', (): void => {
     const plain = {
+      FixtureName: 'Champions League 2024',
       Subscription: { Type: 1, Status: 'Active' },
       Sport: { id: 2, name: 'Football' },
       Location: { id: 3, name: 'Europe' },
@@ -15,6 +17,7 @@ describe('OutrightLeagueFixtureSnapshot', () => {
       Status: 1,
       ExtraData: [{ Name: 'foo', Value: 'bar' }],
       EndDate: '2030-06-01T13:00:00Z',
+      Season: { Id: 2024, Name: '2024-2025' },
     };
     
     const snapshot = plainToInstance(OutrightLeagueFixtureSnapshot, plain, {
@@ -22,6 +25,7 @@ describe('OutrightLeagueFixtureSnapshot', () => {
     });
     
     expect(snapshot).toBeInstanceOf(OutrightLeagueFixtureSnapshot);
+    expect(snapshot.fixtureName).toBe('Champions League 2024');
     expect(snapshot.subscription).toBeInstanceOf(Subscription);
     expect(snapshot.sport).toBeInstanceOf(SportsBodyStructure);
     expect(snapshot.location).toBeInstanceOf(LocationsBodyStructure);
@@ -32,6 +36,9 @@ describe('OutrightLeagueFixtureSnapshot', () => {
     expect(snapshot.status).toBe(1);
     expect(snapshot.endDate).toBeInstanceOf(Date);
     expect(snapshot.endDate?.toISOString()).toBe('2030-06-01T13:00:00.000Z');
+    expect(snapshot.season).toBeInstanceOf(IdNNameRecord);
+    expect(snapshot.season?.id).toBe(2024);
+    expect(snapshot.season?.name).toBe('2024-2025');
   });
 
   it('should handle ISO 8601 date format correctly for EndDate field', (): void => {
@@ -66,6 +73,7 @@ describe('OutrightLeagueFixtureSnapshot', () => {
       excludeExtraneousValues: true,
     });
     
+    expect(snapshot.fixtureName).toBeUndefined();
     expect(snapshot.subscription).toBeUndefined();
     expect(snapshot.sport).toBeUndefined();
     expect(snapshot.location).toBeUndefined();
@@ -73,6 +81,23 @@ describe('OutrightLeagueFixtureSnapshot', () => {
     expect(snapshot.status).toBeUndefined();
     expect(snapshot.extraData).toBeUndefined();
     expect(snapshot.endDate).toBeUndefined();
+    expect(snapshot.season).toBeUndefined();
+  });
+
+  it('should deserialize FixtureName and Season properties correctly', (): void => {
+    const plain = {
+      FixtureName: 'World Cup Final',
+      Season: { Id: 2025, Name: '2025-2026' },
+    };
+    
+    const snapshot = plainToInstance(OutrightLeagueFixtureSnapshot, plain, {
+      excludeExtraneousValues: true,
+    });
+    
+    expect(snapshot.fixtureName).toBe('World Cup Final');
+    expect(snapshot.season).toBeInstanceOf(IdNNameRecord);
+    expect(snapshot.season?.id).toBe(2025);
+    expect(snapshot.season?.name).toBe('2025-2026');
   });
 
   it('should handle partial data with only EndDate provided', (): void => {

--- a/test/entities/core-entities/outright-league/outright-league-fixture.spec.ts
+++ b/test/entities/core-entities/outright-league/outright-league-fixture.spec.ts
@@ -2,10 +2,12 @@ import { plainToInstance } from 'class-transformer';
 import { OutrightLeagueFixture } from '../../../../src/entities/core-entities/outright-league/outright-league-fixture';
 import { Subscription } from '../../../../src/entities/core-entities/common/subscription';
 import { NameValueRecord } from '../../../../src/entities/core-entities/common/name-value-record';
+import { IdNNameRecord } from '../../../../src/entities/core-entities/common/id-and-name-record';
 
 describe('OutrightLeagueFixture', () => {
   it('should deserialize a plain object into an OutrightLeagueFixture instance', (): void => {
     const plain = {
+      FixtureName: 'League Championship 2024',
       Subscription: { Type: 1, Status: 'Active' },
       Sport: { id: 2, name: 'Football' },
       Location: { id: 3, name: 'Europe' },
@@ -13,11 +15,13 @@ describe('OutrightLeagueFixture', () => {
       Status: 1,
       ExtraData: [{ Name: 'foo', Value: 'bar' }],
       EndDate: '2030-06-01T13:00:00Z',
+      Season: { Id: 2024, Name: '2024-2025' },
     };
     const fixture = plainToInstance(OutrightLeagueFixture, plain, {
       excludeExtraneousValues: true,
     });
     expect(fixture).toBeInstanceOf(OutrightLeagueFixture);
+    expect(fixture.fixtureName).toBe('League Championship 2024');
     expect(fixture.subscription).toBeInstanceOf(Subscription);
     expect(fixture.sport).toBeDefined();
     expect(fixture.location).toBeDefined();
@@ -28,6 +32,9 @@ describe('OutrightLeagueFixture', () => {
     expect(fixture.status).toBe(1);
     expect(fixture.endDate).toBeInstanceOf(Date);
     expect(fixture.endDate?.toISOString()).toBe('2030-06-01T13:00:00.000Z');
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2024);
+    expect(fixture.season?.name).toBe('2024-2025');
   });
 
   it('should handle missing properties', (): void => {
@@ -35,6 +42,7 @@ describe('OutrightLeagueFixture', () => {
     const fixture = plainToInstance(OutrightLeagueFixture, plain, {
       excludeExtraneousValues: true,
     });
+    expect(fixture.fixtureName).toBeUndefined();
     expect(fixture.subscription).toBeUndefined();
     expect(fixture.sport).toBeUndefined();
     expect(fixture.location).toBeUndefined();
@@ -42,6 +50,7 @@ describe('OutrightLeagueFixture', () => {
     expect(fixture.status).toBeUndefined();
     expect(fixture.extraData).toBeUndefined();
     expect(fixture.endDate).toBeUndefined();
+    expect(fixture.season).toBeUndefined();
   });
 
   it('should ignore extraneous properties', (): void => {
@@ -50,5 +59,29 @@ describe('OutrightLeagueFixture', () => {
       excludeExtraneousValues: true,
     });
     expect((fixture as unknown as { Extra?: unknown }).Extra).toBeUndefined();
+  });
+
+  it('should deserialize FixtureName property correctly', (): void => {
+    const plain = {
+      FixtureName: 'World Series 2024',
+      Status: 1,
+    };
+    const fixture = plainToInstance(OutrightLeagueFixture, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture.fixtureName).toBe('World Series 2024');
+  });
+
+  it('should deserialize Season property correctly', (): void => {
+    const plain = {
+      Season: { Id: 2025, Name: '2025-2026' },
+      Status: 1,
+    };
+    const fixture = plainToInstance(OutrightLeagueFixture, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2025);
+    expect(fixture.season?.name).toBe('2025-2026');
   });
 });

--- a/test/entities/core-entities/outright-sport/outright-fixture.spec.ts
+++ b/test/entities/core-entities/outright-sport/outright-fixture.spec.ts
@@ -2,11 +2,13 @@ import { plainToInstance } from 'class-transformer';
 import { OutrightFixture } from '../../../../src/entities/core-entities/outright-sport/outright-fixture';
 import { Subscription } from '../../../../src/entities/core-entities/common/subscription';
 import { NameValueRecord } from '../../../../src/entities/core-entities/common/name-value-record';
+import { IdNNameRecord } from '../../../../src/entities/core-entities/common/id-and-name-record';
 import { OutrightParticipant } from '../../../../src/entities/core-entities/outright-sport/outright-participant';
 
 describe('OutrightFixture', () => {
   it('should deserialize a plain object into an OutrightFixture instance', (): void => {
     const plain = {
+      FixtureName: 'World Cup 2024',
       Subscription: { Type: 1, Status: 'Active' },
       Sport: { id: 2, name: 'Football' },
       Location: { id: 3, name: 'Europe' },
@@ -15,9 +17,11 @@ describe('OutrightFixture', () => {
       Status: 1,
       Participants: [{ Id: 10, Name: 'P1' }],
       ExtraData: [{ Name: 'foo', Value: 'bar' }],
+      Season: { Id: 2024, Name: '2024-2025' },
     };
     const fixture = plainToInstance(OutrightFixture, plain, { excludeExtraneousValues: true });
     expect(fixture).toBeInstanceOf(OutrightFixture);
+    expect(fixture.fixtureName).toBe('World Cup 2024');
     expect(fixture.subscription).toBeInstanceOf(Subscription);
     expect(fixture.sport).toBeDefined();
     expect(fixture.location).toBeDefined();
@@ -30,11 +34,15 @@ describe('OutrightFixture', () => {
     expect(Array.isArray(fixture.extraData)).toBe(true);
     expect(fixture.extraData?.[0]).toBeInstanceOf(NameValueRecord);
     expect(fixture.status).toBe(1);
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2024);
+    expect(fixture.season?.name).toBe('2024-2025');
   });
 
   it('should handle missing properties', (): void => {
     const plain = {};
     const fixture = plainToInstance(OutrightFixture, plain, { excludeExtraneousValues: true });
+    expect(fixture.fixtureName).toBeUndefined();
     expect(fixture.subscription).toBeUndefined();
     expect(fixture.sport).toBeUndefined();
     expect(fixture.location).toBeUndefined();
@@ -43,11 +51,32 @@ describe('OutrightFixture', () => {
     expect(fixture.status).toBeUndefined();
     expect(fixture.participants).toBeUndefined();
     expect(fixture.extraData).toBeUndefined();
+    expect(fixture.season).toBeUndefined();
   });
 
   it('should ignore extraneous properties', (): void => {
     const plain = { Status: 2, Extra: 'ignore me' };
     const fixture = plainToInstance(OutrightFixture, plain, { excludeExtraneousValues: true });
     expect((fixture as unknown as { Extra?: unknown }).Extra).toBeUndefined();
+  });
+
+  it('should deserialize FixtureName property correctly', (): void => {
+    const plain = {
+      FixtureName: 'Champions League Final',
+      Status: 1,
+    };
+    const fixture = plainToInstance(OutrightFixture, plain, { excludeExtraneousValues: true });
+    expect(fixture.fixtureName).toBe('Champions League Final');
+  });
+
+  it('should deserialize Season property correctly', (): void => {
+    const plain = {
+      Season: { Id: 2025, Name: '2025-2026' },
+      Status: 1,
+    };
+    const fixture = plainToInstance(OutrightFixture, plain, { excludeExtraneousValues: true });
+    expect(fixture.season).toBeInstanceOf(IdNNameRecord);
+    expect(fixture.season?.id).toBe(2025);
+    expect(fixture.season?.name).toBe('2025-2026');
   });
 });

--- a/test/entities/core-entities/outright-sport/outright-participant.spec.ts
+++ b/test/entities/core-entities/outright-sport/outright-participant.spec.ts
@@ -2,6 +2,7 @@ import { plainToInstance } from 'class-transformer';
 import { OutrightParticipant } from '../../../../src/entities/core-entities/outright-sport/outright-participant';
 import { NameValueRecord } from '../../../../src/entities/core-entities/common/name-value-record';
 import { ActiveParticipant } from '../../../../src/entities/core-entities/enums/active-participant';
+import { FixturePlayer } from '../../../../src/entities/core-entities/fixture/fixture-player';
 
 describe('OutrightParticipant', () => {
   it('should deserialize a plain object into an OutrightParticipant instance', (): void => {
@@ -11,6 +12,12 @@ describe('OutrightParticipant', () => {
       Position: '1st',
       RotationId: 150,
       IsActive: ActiveParticipant.Active,
+      Form: 'WWDLW',
+      Formation: '4-3-3',
+      FixturePlayers: [{ PlayerId: 10, ShirtNumber: '10' }],
+      Gender: 1,
+      AgeCategory: 21,
+      Type: 1,
       ExtraData: [{ Name: 'foo', Value: 'bar' }],
     };
     const participant = plainToInstance(OutrightParticipant, plain, {
@@ -22,6 +29,13 @@ describe('OutrightParticipant', () => {
     expect(participant.position).toBe('1st');
     expect(participant.rotationId).toBe(150);
     expect(participant.isActive).toBe(ActiveParticipant.Active);
+    expect(participant.form).toBe('WWDLW');
+    expect(participant.formation).toBe('4-3-3');
+    expect(Array.isArray(participant.fixturePlayers)).toBe(true);
+    expect(participant.fixturePlayers?.[0]).toBeInstanceOf(FixturePlayer);
+    expect(participant.gender).toBe(1);
+    expect(participant.ageCategory).toBe(21);
+    expect(participant.type).toBe(1);
     expect(Array.isArray(participant.extraData)).toBe(true);
     expect(participant.extraData?.[0]).toBeInstanceOf(NameValueRecord);
   });
@@ -36,6 +50,12 @@ describe('OutrightParticipant', () => {
     expect(participant.position).toBeUndefined();
     expect(participant.rotationId).toBeUndefined();
     expect(participant.isActive).toBeUndefined();
+    expect(participant.form).toBeUndefined();
+    expect(participant.formation).toBeUndefined();
+    expect(participant.fixturePlayers).toBeUndefined();
+    expect(participant.gender).toBeUndefined();
+    expect(participant.ageCategory).toBeUndefined();
+    expect(participant.type).toBeUndefined();
     expect(participant.extraData).toBeUndefined();
   });
 
@@ -57,5 +77,63 @@ describe('OutrightParticipant', () => {
       excludeExtraneousValues: true,
     });
     expect(participant.rotationId).toBe(300);
+  });
+
+  it('should deserialize Form property correctly', (): void => {
+    const plain = {
+      Id: 1,
+      Name: 'Team A',
+      Form: 'WWWWW',
+    };
+    const participant = plainToInstance(OutrightParticipant, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(participant.form).toBe('WWWWW');
+  });
+
+  it('should deserialize Formation property correctly', (): void => {
+    const plain = {
+      Id: 1,
+      Name: 'Team A',
+      Formation: '4-4-2',
+    };
+    const participant = plainToInstance(OutrightParticipant, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(participant.formation).toBe('4-4-2');
+  });
+
+  it('should deserialize FixturePlayers property correctly', (): void => {
+    const plain = {
+      Id: 1,
+      Name: 'Team A',
+      FixturePlayers: [
+        { PlayerId: 10, ShirtNumber: '10', IsCaptain: true },
+        { PlayerId: 7, ShirtNumber: '7', IsCaptain: false },
+      ],
+    };
+    const participant = plainToInstance(OutrightParticipant, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(Array.isArray(participant.fixturePlayers)).toBe(true);
+    expect(participant.fixturePlayers?.length).toBe(2);
+    expect(participant.fixturePlayers?.[0]).toBeInstanceOf(FixturePlayer);
+    expect(participant.fixturePlayers?.[0].playerId).toBe(10);
+  });
+
+  it('should deserialize Gender, AgeCategory, and Type properties correctly', (): void => {
+    const plain = {
+      Id: 1,
+      Name: 'Team A',
+      Gender: 1,
+      AgeCategory: 18,
+      Type: 2,
+    };
+    const participant = plainToInstance(OutrightParticipant, plain, {
+      excludeExtraneousValues: true,
+    });
+    expect(participant.gender).toBe(1);
+    expect(participant.ageCategory).toBe(18);
+    expect(participant.type).toBe(2);
   });
 });


### PR DESCRIPTION
# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Enhances the <code>OutrightFixture</code>, <code>OutrightLeagueFixture</code>, and <code>OutrightParticipant</code> entities by adding missing metadata fields such as season, formation, and player lineups to improve data coverage. Updates API response structures like <code>OutrightFixtureBodyStructure</code> and <code>OutrightLeagueFixtureSnapshot</code> to ensure these new properties are correctly exposed and validated through comprehensive unit tests.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/98?tool=ast&topic=Fixture+Metadata>Fixture Metadata</a>
        </td><td>Adds <code>fixtureName</code> and <code>season</code> properties to fixture entities and their corresponding API response structures to support enhanced metadata.<details><summary>Modified files (12)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li>
<li>sample/feed-sample/package-lock.json</li>
<li>src/api/common/body-entities/responses/outright-fixture-body-structure.ts</li>
<li>src/api/common/body-entities/responses/outright-league-fixture-snapshot.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-fixture.ts</li>
<li>src/entities/core-entities/outright-sport/outright-fixture.ts</li>
<li>test/api/common/body-entities/responses/outright-fixture-body-structure.spec.ts</li>
<li>test/api/common/body-entities/responses/outright-league-fixture-snapshot.spec.ts</li>
<li>test/entities/core-entities/outright-league/outright-league-fixture.spec.ts</li>
<li>test/entities/core-entities/outright-sport/outright-fixture.spec.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>Phil1903</td><td>Fixed-version</td><td>January 26, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Release-version-3.8.3-...</td><td>January 25, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/98?tool=ast&topic=Participant+Details>Participant Details</a>
        </td><td>Introduces <code>form</code>, <code>formation</code>, <code>fixturePlayers</code>, and demographic fields to the <code>OutrightParticipant</code> entity to provide detailed participant information.<details><summary>Modified files (2)</summary><ul><li>src/entities/core-entities/outright-sport/outright-participant.ts</li>
<li>test/entities/core-entities/outright-sport/outright-participant.spec.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Add-rotationId-and-isA...</td><td>July 28, 2025</td></tr>
<tr><td>benny.h@lsports.eu</td><td>change-entities-inside...</td><td>September 22, 2024</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/98?tool=ast>(Baz)</a>.