### PR TITLE
Update to version 3.9.3 with improved HTTP error handling and updated…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.3](#version-393)
 - [Version 3.9.2](#version-392)
 - [Version 3.9.1](#version-391)
 - [Version 3.8.3](#version-383)
@@ -23,6 +24,28 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.3
+
+Improves HTTP error handling for non-standard API error bodies and updates the snapshot API sample for fixture markets and logging.
+
+### Fixed
+
+- **HTTP error responses without TRADE360 envelope**
+  - When the server returns a plain JSON error (e.g. `{ "error": "..." }`) instead of a `Header`/`Body` structure, `HttpResponseError` now surfaces that message (and common `message` / `Message` fields) instead of reporting only that the header is missing.
+  - Raw body remains available on the error `context` for debugging.
+
+### Samples
+
+- **snapshot-api-sample**
+  - Demo logging uses a small helper so counts work when snapshot endpoints return an array at runtime while typings still describe a single element.
+  - In-Play and Pre-Match **Get Fixture Markets** now call **Get Fixtures** first and pass **fixture IDs** (capped per request), which matches typical snapshot API usage and avoids generic server errors when only `sports` was sent.
+
+### Backward Compatibility
+
+No breaking changes to public method signatures or expected success-response shapes.
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.2",
+  "version": "3.9.3",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/sample/customer-api-sample/package-lock.json
+++ b/sample/customer-api-sample/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "fs": "^0.0.1-security",
         "lodash": "^4.17.21",
         "trade360-nodejs-sdk": "file:../../"
       },
@@ -21,7 +20,7 @@
       }
     },
     "../..": {
-      "version": "3.8.0",
+      "version": "3.9.2",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",
@@ -193,11 +192,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/sample/customer-api-sample/package.json
+++ b/sample/customer-api-sample/package.json
@@ -13,7 +13,6 @@
   "description": "",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "fs": "^0.0.1-security",
     "lodash": "^4.17.21",
     "trade360-nodejs-sdk": "file:../../"
   },

--- a/sample/feed-sample/package-lock.json
+++ b/sample/feed-sample/package-lock.json
@@ -11,7 +11,6 @@
       "dependencies": {
         "bunyan": "^1.8.15",
         "dotenv": "^16.4.5",
-        "fs": "^0.0.1-security",
         "pino": "^9.4.0",
         "trade360-nodejs-sdk": "file:../../",
         "winston": "^3.14.2"
@@ -23,7 +22,7 @@
       }
     },
     "../..": {
-      "version": "3.9.0",
+      "version": "3.9.2",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",
@@ -418,11 +417,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/fn.name/-/fn.name-1.1.0.tgz",
       "integrity": "sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw=="
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/glob": {
       "version": "6.0.4",

--- a/sample/feed-sample/package.json
+++ b/sample/feed-sample/package.json
@@ -13,7 +13,6 @@
   "dependencies": {
     "bunyan": "^1.8.15",
     "dotenv": "^16.4.5",
-    "fs": "^0.0.1-security",
     "pino": "^9.4.0",
     "trade360-nodejs-sdk": "file:../../",
     "winston": "^3.14.2"

--- a/sample/snapshot-api-sample/package-lock.json
+++ b/sample/snapshot-api-sample/package-lock.json
@@ -10,7 +10,6 @@
       "license": "ISC",
       "dependencies": {
         "dotenv": "^16.4.5",
-        "fs": "^0.0.1-security",
         "lodash": "^4.17.21",
         "trade360-nodejs-sdk": "file:../../"
       },
@@ -21,7 +20,7 @@
       }
     },
     "../..": {
-      "version": "3.4.2",
+      "version": "3.9.2",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",
@@ -193,11 +192,6 @@
       "funding": {
         "url": "https://dotenvx.com"
       }
-    },
-    "node_modules/fs": {
-      "version": "0.0.1-security",
-      "resolved": "https://registry.npmjs.org/fs/-/fs-0.0.1-security.tgz",
-      "integrity": "sha512-3XY9e1pP0CVEUCdj5BmfIZxRBTSDycnbqhIOGec9QYtmVH2fbLpj86CFWkrNOkt/Fvty4KZG5lTglL9j/gJ87w=="
     },
     "node_modules/lodash": {
       "version": "4.17.21",

--- a/sample/snapshot-api-sample/package.json
+++ b/sample/snapshot-api-sample/package.json
@@ -1,6 +1,6 @@
 {
   "name": "snapshot-api-sample",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "main": "src/index.ts",
   "scripts": {
     "start": "ts-node src/index.ts",
@@ -12,7 +12,6 @@
   "description": "",
   "dependencies": {
     "dotenv": "^16.4.5",
-    "fs": "^0.0.1-security",
     "lodash": "^4.17.21",
     "trade360-nodejs-sdk": "file:../../"
   },

--- a/sample/snapshot-api-sample/src/index.ts
+++ b/sample/snapshot-api-sample/src/index.ts
@@ -39,10 +39,6 @@ const config = getConfig();
 
 let logger = console;
 
-/**
- * Snapshot endpoints return an array in the HTTP Body at runtime; SDK method return types
- * are still declared as a single element (TR-23142). This counts items for demo logs only.
- */
 function snapshotResultCountForLog(response: unknown): number {
   if (response == null) {
     return 0;
@@ -219,7 +215,9 @@ const initApiSample = async () => {
 
 const getInPlayFixtures = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetFixtureRequestDto({
-    sports: [452674]
+    sports: [6046],
+    locations: [171],
+    leagues: [170]
   });
 
   const response = await inplaySnapshotHttpClient.getFixtures(request);
@@ -229,7 +227,8 @@ const getInPlayFixtures = async (inplaySnapshotHttpClient: InPlaySnapshotApiClie
 
 const getInPlayLivescores = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetLivescoreRequestDto({
-    sports: [452674]
+    sports: [6046],
+    locations: [171]
   });
 
   const response = await inplaySnapshotHttpClient.getLivescores(request);
@@ -238,9 +237,11 @@ const getInPlayLivescores = async (inplaySnapshotHttpClient: InPlaySnapshotApiCl
 };
 
 const getInPlayFixtureMarkets = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
-  const sportIds = [452674];
   const fixturesResponse = await inplaySnapshotHttpClient.getFixtures(
-    new GetFixtureRequestDto({ sports: sportIds }),
+    new GetFixtureRequestDto({     
+      sports: [6046],
+      locations: [171] 
+    }),
   );
   const fixtureIds = snapshotBodyAsArray(fixturesResponse)
     .map((row) => row.fixtureId)
@@ -255,7 +256,8 @@ const getInPlayFixtureMarkets = async (inplaySnapshotHttpClient: InPlaySnapshotA
 
   const fixturesForMarkets = fixtureIds.slice(0, SAMPLE_MARKETS_MAX_FIXTURE_IDS);
   const request = new GetMarketRequestDto({
-    sports: sportIds,
+    sports: 6046,
+    locations: 171,
     fixtures: fixturesForMarkets,
   });
 
@@ -268,7 +270,8 @@ const getInPlayFixtureMarkets = async (inplaySnapshotHttpClient: InPlaySnapshotA
 
 const getInPlayEvents = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetInPlayEventRequestDto({
-    sports: [452674]
+    sports: [6046],
+    locations: [171]
   });
 
   const response = await inplaySnapshotHttpClient.getEvents(request);
@@ -278,7 +281,8 @@ const getInPlayEvents = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient
 
 const getPreMatchFixtures = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetFixtureRequestDto({
-    sports: [452674]
+    sports: [6046],
+    locations: [4]
   });
 
   const response = await prematchSnapshotHttpClient.getFixtures(request);
@@ -288,7 +292,8 @@ const getPreMatchFixtures = async (prematchSnapshotHttpClient: PreMatchSnapshotA
 
 const getPreMatchLivescores = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetLivescoreRequestDto({
-    sports: [452674]
+    sports: [35232],
+    locations: [73]
   });
 
   const response = await prematchSnapshotHttpClient.getLivescores(request);
@@ -297,9 +302,11 @@ const getPreMatchLivescores = async (prematchSnapshotHttpClient: PreMatchSnapsho
 };
 
 const getPreMatchFixtureMarkets = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
-  const sportIds = [452674];
   const fixturesResponse = await prematchSnapshotHttpClient.getFixtures(
-    new GetFixtureRequestDto({ sports: sportIds }),
+    new GetFixtureRequestDto({ 
+      sports: [35232],
+      locations: [73]
+    }),
   );
   const fixtureIds = snapshotBodyAsArray(fixturesResponse)
     .map((row) => row.fixtureId)
@@ -314,7 +321,8 @@ const getPreMatchFixtureMarkets = async (prematchSnapshotHttpClient: PreMatchSna
 
   const fixturesForMarkets = fixtureIds.slice(0, SAMPLE_MARKETS_MAX_FIXTURE_IDS);
   const request = new GetMarketRequestDto({
-    sports: sportIds,
+    sports: [35232],
+    locations: [73],
     fixtures: fixturesForMarkets,
   });
 
@@ -327,7 +335,8 @@ const getPreMatchFixtureMarkets = async (prematchSnapshotHttpClient: PreMatchSna
 
 const getPreMatchEvents = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetEventRequestDto({
-    sports : [452674]
+    sports : [35232],
+    locations: [73]
   });
 
   const response = await prematchSnapshotHttpClient.getEvents(request);

--- a/sample/snapshot-api-sample/src/index.ts
+++ b/sample/snapshot-api-sample/src/index.ts
@@ -39,6 +39,28 @@ const config = getConfig();
 
 let logger = console;
 
+/**
+ * Snapshot endpoints return an array in the HTTP Body at runtime; SDK method return types
+ * are still declared as a single element (TR-23142). This counts items for demo logs only.
+ */
+function snapshotResultCountForLog(response: unknown): number {
+  if (response == null) {
+    return 0;
+  }
+  return Array.isArray(response) ? response.length : 1;
+}
+
+/** Runtime bodies are often arrays; SDK typings may still be a single element (TR-23142). */
+function snapshotBodyAsArray<T>(response: T | T[] | undefined): T[] {
+  if (response == null) {
+    return [];
+  }
+  return Array.isArray(response) ? response : [response];
+}
+
+/** Avoid very large GetFixtureMarkets requests in the interactive demo. */
+const SAMPLE_MARKETS_MAX_FIXTURE_IDS = 50;
+
 const rl = readline.createInterface({
   input: process.stdin,
   output: process.stdout,
@@ -197,155 +219,186 @@ const initApiSample = async () => {
 
 const getInPlayFixtures = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetFixtureRequestDto({
-    sports: [6046]
+    sports: [452674]
   });
 
   const response = await inplaySnapshotHttpClient.getFixtures(request);
 
-  logger.log(`${response?.length} Fixtures retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Fixtures retrieved.`);
 };
 
 const getInPlayLivescores = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetLivescoreRequestDto({
-    sports: [6046]
+    sports: [452674]
   });
 
   const response = await inplaySnapshotHttpClient.getLivescores(request);
 
-  logger.log(`${response?.length} Livescores retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Livescores retrieved.`);
 };
 
 const getInPlayFixtureMarkets = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
+  const sportIds = [452674];
+  const fixturesResponse = await inplaySnapshotHttpClient.getFixtures(
+    new GetFixtureRequestDto({ sports: sportIds }),
+  );
+  const fixtureIds = snapshotBodyAsArray(fixturesResponse)
+    .map((row) => row.fixtureId)
+    .filter((id): id is number => typeof id === 'number' && Number.isFinite(id));
+
+  if (fixtureIds.length === 0) {
+    logger.log(
+      'No fixture IDs from GetFixtures; skipping markets (snapshot markets are scoped to fixtures).',
+    );
+    return;
+  }
+
+  const fixturesForMarkets = fixtureIds.slice(0, SAMPLE_MARKETS_MAX_FIXTURE_IDS);
   const request = new GetMarketRequestDto({
-    sports: [6046]
+    sports: sportIds,
+    fixtures: fixturesForMarkets,
   });
 
   const response = await inplaySnapshotHttpClient.getFixtureMarkets(request);
 
-  logger.log(`${response?.length} Fixture Markets retrieved.`);
+  logger.log(
+    `${snapshotResultCountForLog(response)} Fixture Markets retrieved (using ${fixturesForMarkets.length} fixture ID(s)).`,
+  );
 };
 
 const getInPlayEvents = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
   const request = new GetInPlayEventRequestDto({
-    sports: [6046]
+    sports: [452674]
   });
 
   const response = await inplaySnapshotHttpClient.getEvents(request);
 
-  logger.log(`${response?.length} Events retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Events retrieved.`);
 };
 
 const getPreMatchFixtures = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetFixtureRequestDto({
-    sports: [6046]
+    sports: [452674]
   });
 
   const response = await prematchSnapshotHttpClient.getFixtures(request);
 
-  logger.log(`${response?.length} Fixtures retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Fixtures retrieved.`);
 };
 
 const getPreMatchLivescores = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetLivescoreRequestDto({
-    sports: [6046]
+    sports: [452674]
   });
 
   const response = await prematchSnapshotHttpClient.getLivescores(request);
 
-  logger.log(`${response?.length} Livescores retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Livescores retrieved.`);
 };
 
 const getPreMatchFixtureMarkets = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
+  const sportIds = [452674];
+  const fixturesResponse = await prematchSnapshotHttpClient.getFixtures(
+    new GetFixtureRequestDto({ sports: sportIds }),
+  );
+  const fixtureIds = snapshotBodyAsArray(fixturesResponse)
+    .map((row) => row.fixtureId)
+    .filter((id): id is number => typeof id === 'number' && Number.isFinite(id));
+
+  if (fixtureIds.length === 0) {
+    logger.log(
+      'No fixture IDs from GetFixtures; skipping markets (snapshot markets are scoped to fixtures).',
+    );
+    return;
+  }
+
+  const fixturesForMarkets = fixtureIds.slice(0, SAMPLE_MARKETS_MAX_FIXTURE_IDS);
   const request = new GetMarketRequestDto({
-    sports: [6046]
+    sports: sportIds,
+    fixtures: fixturesForMarkets,
   });
 
   const response = await prematchSnapshotHttpClient.getFixtureMarkets(request);
 
-  logger.log(`${response?.length} Fixture Markets retrieved.`);
+  logger.log(
+    `${snapshotResultCountForLog(response)} Fixture Markets retrieved (using ${fixturesForMarkets.length} fixture ID(s)).`,
+  );
 };
 
 const getPreMatchEvents = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetEventRequestDto({
-    sports : [6046]
+    sports : [452674]
   });
 
   const response = await prematchSnapshotHttpClient.getEvents(request);
 
-  logger.log(`${response?.length} Events retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Events retrieved.`);
 };
 
 
 const getOutrightEvents = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightEventRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightEvents(request);
 
-  logger.log(`${response?.length} Outright Events retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright Events retrieved.`);
 };
 
 
 const getOutrightFixtures = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightFixtureRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightFixtures(request);
 
-  logger.log(`${response?.length} Outright Fixtures retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright Fixtures retrieved.`);
 };
 
 const getOutrightScores = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightLivescoreRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightScores(request);
 
-  logger.log(`${response?.length} Outright Scores retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright Scores retrieved.`);
 };
 
 const getOutrightFixtureMarkets = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightMarketRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightFixtureMarkets(request);
 
-  logger.log(`${response?.length} Outright Fixture Markets retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright Fixture Markets retrieved.`);
 };
 
 
 const getOutrightLeagues = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightLeaguesRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightLeagues(request);
 
-  logger.log(`${response?.length} Outright Leagues retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright Leagues retrieved.`);
 };
 
 const getOutrightLeagueMarkets = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightLeagueMarketRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightLeagueMarkets(request);
 
-  logger.log(`${response?.length} Outright League Markets retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright League Markets retrieved.`);
 };
 
 const getOutrightLeagueEvents = async (prematchSnapshotHttpClient: PreMatchSnapshotApiClient): Promise<void> => {
   const request = new GetOutrightLeagueEventsRequestDto({
-    sports: [6046]
   });
 
   const response = await prematchSnapshotHttpClient.getOutrightLeagueEvents(request);
 
-  logger.log(`${response?.length} Outright League Events retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} Outright League Events retrieved.`);
 };
 
 const getInPlayOutrightLeagues = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
@@ -354,7 +407,7 @@ const getInPlayOutrightLeagues = async (inplaySnapshotHttpClient: InPlaySnapshot
 
   const response = await inplaySnapshotHttpClient.getOutrightLeagues(request);
 
-  logger.log(`${response?.length} In-Play Outright Leagues retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} In-Play Outright Leagues retrieved.`);
 };
 
 const getInPlayOutrightLeagueMarkets = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
@@ -363,7 +416,7 @@ const getInPlayOutrightLeagueMarkets = async (inplaySnapshotHttpClient: InPlaySn
 
   const response = await inplaySnapshotHttpClient.getOutrightLeagueMarkets(request);
 
-  logger.log(`${response?.length} In-Play Outright League Markets retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} In-Play Outright League Markets retrieved.`);
 };
 
 const getInPlayOutrightLeagueEvents = async (inplaySnapshotHttpClient: InPlaySnapshotApiClient): Promise<void> => {
@@ -372,7 +425,7 @@ const getInPlayOutrightLeagueEvents = async (inplaySnapshotHttpClient: InPlaySna
 
   const response = await inplaySnapshotHttpClient.getOutrightLeagueEvents(request);
 
-  logger.log(`${response?.length} In-Play Outright League Events retrieved.`);
+  logger.log(`${snapshotResultCountForLog(response)} In-Play Outright League Events retrieved.`);
 };
 
 initApiSample();

--- a/src/api/base-http-client/base-http-client.ts
+++ b/src/api/base-http-client/base-http-client.ts
@@ -166,6 +166,27 @@ export abstract class BaseHttpClient {
   }
 
   /**
+   * When the HTTP error body is not a TRADE360 envelope (no Header), try to read a
+   * message from common API shapes (e.g. { error: "..." }).
+   */
+  private static messageFromNonEnvelopeErrorBody(data: unknown): string | undefined {
+    if (isNil(data)) {
+      return undefined;
+    }
+    if (typeof data === 'string') {
+      return data;
+    }
+    if (typeof data === 'object' && !isArray(data)) {
+      const record = data as Record<string, unknown>;
+      const candidate = record.error ?? record.Error ?? record.message ?? record.Message;
+      if (typeof candidate === 'string' && candidate.length > 0) {
+        return candidate;
+      }
+    }
+    return undefined;
+  }
+
+  /**
    * This method is responsible for handling the error response.
    * It throws an error with the appropriate message based on the error
    * response received. If the error response is not an AxiosError, it
@@ -213,7 +234,14 @@ export abstract class BaseHttpClient {
 
     const transformed = TransformerUtil.transform(data, responsePayloadDto);
     if (!transformed.header) {
-      throw new HttpResponseError("Missing 'header' in error response", { context: data });
+      const detail = BaseHttpClient.messageFromNonEnvelopeErrorBody(data);
+      const statusCode = response.status;
+      const serialized =
+        typeof data === 'object' && !isNil(data) ? JSON.stringify(data) : String(data);
+      throw new HttpResponseError(
+        detail ?? `response does not include a Header object (HTTP ${statusCode})`,
+        { context: serialized, cause: errorResponse },
+      );
     }
     const { httpStatusCode, errors } = transformed.header;
 


### PR DESCRIPTION
# User description
… snapshot API samples.

- Enhanced error handling for non-standard API error bodies, allowing better visibility of error messages.
- Updated snapshot API sample to correctly handle array responses and improved logging for fixture markets.
- No breaking changes introduced.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Improve HTTP error reporting in <code>BaseHttpClient</code> so <code>HttpResponseError</code> surfaces message payloads from non-envelope responses while keeping the raw body context and documenting the fix in the changelog and release version update. Align the snapshot API sample flow by normalizing array responses, capping fixture IDs, and pruning redundant <code>fs</code> dependencies so demo logging and fixture-market calls mirror real usage.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/100?tool=ast&topic=HTTP+Error+Handling>HTTP Error Handling</a>
        </td><td>Improve <code>BaseHttpClient</code> error handling by reading common <code>error</code>/<code>message</code> fields when no TRADE360 envelope exists, keep the raw body in the error context, update the version in <code>package.json</code>, and document the fix in <code>CHANGELOG.md</code> for the 3.9.3 release.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>package.json</li>
<li>src/api/base-http-client/base-http-client.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TR-22187: Add Provider...</td><td>February 01, 2026</td></tr>
<tr><td>PavelTemno</td><td>update versions</td><td>January 27, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/100?tool=ast&topic=Snapshot+Sample+Flow>Snapshot Sample Flow</a>
        </td><td>Normalize the snapshot samples by treating runtime responses as arrays, restricting market requests with up to 50 fixture IDs obtained from <code>getFixtures</code>, improving demo logging counts, and removing unused <code>fs</code> dependencies in all sample manifests/locks so the provided flows match actual snapshot API behavior.<details><summary>Modified files (7)</summary><ul><li>sample/customer-api-sample/package-lock.json</li>
<li>sample/customer-api-sample/package.json</li>
<li>sample/feed-sample/package-lock.json</li>
<li>sample/feed-sample/package.json</li>
<li>sample/snapshot-api-sample/package-lock.json</li>
<li>sample/snapshot-api-sample/package.json</li>
<li>sample/snapshot-api-sample/src/index.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>PavelTemno</td><td>fix outright fixture a...</td><td>January 26, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>fixing apis to retriev...</td><td>November 16, 2025</td></tr></table></details></td></tr></table>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/100?tool=ast>(Baz)</a>.