### PR TITLE
Bump package version to 3.9.5 for npm publish.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.5](#version-395)
 - [Version 3.9.4](#version-394)
 - [Version 3.9.3](#version-393)
 - [Version 3.9.2](#version-392)
@@ -25,6 +26,17 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.5
+
+Version bump to unblock npm publish after `3.9.4` was already published.
+
+### Changed
+
+- **Release version only**
+  - Updated package version from `3.9.4` to `3.9.5` to satisfy npm immutable versioning.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",


### PR DESCRIPTION
# User description
Publish of 3.9.4 is blocked by npm immutability, so this updates package metadata and changelog to allow a valid new release.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update changelog and package metadata to document and apply the 3.9.5 release. Ensure npm publish can proceed by raising the SDK version metadata from <code>3.9.4</code> to <code>3.9.5</code>.


<details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Bump package version t...</td><td>May 07, 2026</td></tr>
<tr><td>PavelTemno</td><td>update versions</td><td>January 27, 2026</td></tr></table></details>
This pull request is reviewed by Baz. Review like a pro on <a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/102?tool=ast>(Baz)</a>.