### PR TITLE
Update to version 3.9.5 with fixes for nested outright league event deserialization.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.5](#version-395)
 - [Version 3.9.4](#version-394)
 - [Version 3.9.3](#version-393)
 - [Version 3.9.2](#version-392)
@@ -25,6 +26,28 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.5
+
+Fixes unstable deserialization of nested outright league feed events (message types 38, 40, and 43).
+
+### Fixed
+
+- **Circular imports in outright league event transformation (TR-23836)**
+  - Removed barrel (`@entities` / `@lsports/entities`) imports from `transformToEventInstance`, `OutrightLeagueCompetitions`, and `OutrightCompetition` in favor of direct module imports.
+  - Event type resolution now builds the class map at call time so nested `Events` are always transformed into proper instances (`fixtureId`, `outrightLeague`, `markets`, `bets`) instead of intermittently remaining raw PascalCase plain objects.
+  - Resolves `TypeError: transformToEventInstance is not a function` in some module load orders.
+
+### Testing
+
+- Added regression tests for message types 38, 40, and 43 nested event deserialization.
+- Added unit tests for `transformToEventInstance`.
+
+### Backward Compatibility
+
+No breaking changes to public APIs. Consumers who added PascalCase fallbacks for nested outright league events can rely on camelCase class instances consistently after upgrading.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.9.4",
+      "version": "3.9.5",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.4",
+  "version": "3.9.5",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/entities/core-entities/market/market-event.ts
+++ b/src/entities/core-entities/market/market-event.ts
@@ -1,6 +1,6 @@
 import { Expose, Type } from 'class-transformer';
 
-import { BaseEntity } from '@entities';
+import { BaseEntity } from '../../message-types';
 
 import { Market } from './market';
 

--- a/src/entities/core-entities/outright-league/outright-league-competitions.ts
+++ b/src/entities/core-entities/outright-league/outright-league-competitions.ts
@@ -1,6 +1,7 @@
 import { Expose, Transform } from 'class-transformer';
 
-import { BaseEntity, transformToEventInstance } from '@entities';
+import { BaseEntity } from '../../message-types';
+import { transformToEventInstance } from '../utilities/transform-event-instance';
 
 export class OutrightLeagueCompetitions<TEvent extends BaseEntity> {
   @Expose({ name: 'Id' })

--- a/src/entities/core-entities/outright-league/outright-league-fixture-event.ts
+++ b/src/entities/core-entities/outright-league/outright-league-fixture-event.ts
@@ -1,6 +1,6 @@
 import { Expose, Type } from 'class-transformer';
 
-import { BaseEntity } from '@entities';
+import { BaseEntity } from '../../message-types';
 
 import { OutrightLeagueFixture } from './outright-league-fixture';
 

--- a/src/entities/core-entities/outright-league/outright-league-fixture.ts
+++ b/src/entities/core-entities/outright-league/outright-league-fixture.ts
@@ -1,6 +1,7 @@
 import { Expose, Type } from 'class-transformer';
 
-import { Location, Sport } from '@lsports/entities';
+import { Location } from '../fixture/location';
+import { Sport } from '../fixture/sport';
 import { FixtureStatus } from '@lsports/enums';
 import { IdNNameRecord, NameValueRecord, Subscription } from '@lsports/entities/common';
 

--- a/src/entities/core-entities/outright-sport/outright-competition.ts
+++ b/src/entities/core-entities/outright-sport/outright-competition.ts
@@ -1,6 +1,7 @@
 import { Expose, Transform } from 'class-transformer';
 
-import { BaseEntity, transformToEventInstance } from '@entities';
+import { BaseEntity } from '../../message-types';
+import { transformToEventInstance } from '../utilities/transform-event-instance';
 
 export class OutrightCompetition<TEvent extends BaseEntity> {
   @Expose({ name: 'Id' })

--- a/src/entities/core-entities/outright-sport/outright-fixture-event.ts
+++ b/src/entities/core-entities/outright-sport/outright-fixture-event.ts
@@ -1,6 +1,6 @@
 import { Expose, Type } from 'class-transformer';
 
-import { BaseEntity } from '@entities';
+import { BaseEntity } from '../../message-types';
 
 import { OutrightFixture } from './outright-fixture';
 

--- a/src/entities/core-entities/outright-sport/outright-score-event.ts
+++ b/src/entities/core-entities/outright-sport/outright-score-event.ts
@@ -1,6 +1,6 @@
 import { Expose, Type } from 'class-transformer';
 
-import { BaseEntity } from '@entities';
+import { BaseEntity } from '../../message-types';
 
 import { OutrightScore } from './outright-score';
 

--- a/src/entities/core-entities/utilities/transform-event-instance.ts
+++ b/src/entities/core-entities/utilities/transform-event-instance.ts
@@ -1,11 +1,9 @@
 import { find, has, isArray, isEmpty, isNil, keys } from 'lodash';
 
-import {
-  MarketEvent,
-  OutrightFixtureEvent,
-  OutrightLeagueFixtureEvent,
-  OutrightScoreEvent,
-} from '@lsports/entities';
+import { MarketEvent } from '../market/market-event';
+import { OutrightFixtureEvent } from '../outright-sport/outright-fixture-event';
+import { OutrightScoreEvent } from '../outright-sport/outright-score-event';
+import { OutrightLeagueFixtureEvent } from '../outright-league/outright-league-fixture-event';
 import { TransformerUtil } from '@utilities';
 
 /**
@@ -19,14 +17,17 @@ interface IEventTypeMap {
 }
 
 /**
- * map of event types to event classes
+ * Resolved at call time so event classes are defined even when this module
+ * loads while core-entities/index.ts is still initializing (TR-23836).
  */
-const eventTypeMap: IEventTypeMap = {
-  OutrightScore: OutrightScoreEvent,
-  OutrightFixture: OutrightFixtureEvent,
-  Markets: MarketEvent,
-  OutrightLeague: OutrightLeagueFixtureEvent,
-};
+function getEventTypeMap(): IEventTypeMap {
+  return {
+    OutrightScore: OutrightScoreEvent,
+    OutrightFixture: OutrightFixtureEvent,
+    Markets: MarketEvent,
+    OutrightLeague: OutrightLeagueFixtureEvent,
+  };
+}
 
 /**
  * get the event class based on the object properties
@@ -40,6 +41,7 @@ function getEventClass(
   | typeof OutrightFixtureEvent
   | typeof MarketEvent
   | typeof OutrightLeagueFixtureEvent {
+  const eventTypeMap = getEventTypeMap();
   const eventType = find(keys(eventTypeMap), (key) => has(obj, key) && !isNil(obj[key]));
   return eventTypeMap[eventType as keyof IEventTypeMap];
 }

--- a/test/entities/core-entities/outright-league/nested-event-transform.spec.ts
+++ b/test/entities/core-entities/outright-league/nested-event-transform.spec.ts
@@ -1,0 +1,90 @@
+import { plainToInstance } from 'class-transformer';
+
+import { MarketEvent, OutrightLeagueFixtureEvent } from '@lsports/entities';
+import {
+  OutrightLeagueFixtureUpdate,
+  OutrightLeagueMarketUpdate,
+  OutrightLeagueSettlementUpdate,
+} from '../../../../src/entities/message-types';
+
+describe('Outright league nested event transform (TR-23836)', () => {
+  const competitionPayload38 = {
+    Id: 1,
+    Name: 'C',
+    Type: 1,
+    Competitions: [
+      {
+        Id: 10,
+        Name: 'Sub',
+        Type: 2,
+        Events: [{ FixtureId: 99, OutrightLeague: { Status: 1 } }],
+      },
+    ],
+  };
+
+  const competitionPayload40 = {
+    Id: 1,
+    Name: 'C',
+    Type: 1,
+    Competitions: [
+      {
+        Id: 10,
+        Name: 'Sub',
+        Type: 2,
+        Events: [
+          {
+            FixtureId: 99,
+            Markets: [{ Id: 1, Name: 'M1', Bets: [{ Id: 2, Name: 'B1', Status: 1 }] }],
+          },
+        ],
+      },
+    ],
+  };
+
+  it('type 38: nested events become OutrightLeagueFixtureEvent with camelCase keys', () => {
+    const msg = plainToInstance(
+      OutrightLeagueFixtureUpdate,
+      { Competition: competitionPayload38 },
+      { excludeExtraneousValues: true },
+    );
+    const event = msg?.competition?.competitions?.[0]?.events?.[0];
+
+    expect(event).toBeInstanceOf(OutrightLeagueFixtureEvent);
+    expect(event?.fixtureId).toBe(99);
+    expect((event as { FixtureId?: number })?.FixtureId).toBeUndefined();
+  });
+
+  it('type 40: nested events become MarketEvent with mapped markets and bets', () => {
+    const msg = plainToInstance(
+      OutrightLeagueMarketUpdate,
+      { Competition: competitionPayload40 },
+      { excludeExtraneousValues: true },
+    );
+    const event = msg?.competition?.competitions?.[0]?.events?.[0];
+    const market = event?.markets?.[0];
+    const bet = market?.bets?.[0];
+
+    expect(event).toBeInstanceOf(MarketEvent);
+    expect(event?.fixtureId).toBe(99);
+    expect(market?.id).toBe(1);
+    expect(market?.name).toBe('M1');
+    expect(bet?.id).toBe('2');
+    expect(bet?.name).toBe('B1');
+    expect((event as { FixtureId?: number })?.FixtureId).toBeUndefined();
+    expect((market as { Id?: number })?.Id).toBeUndefined();
+    expect((bet as { Id?: number })?.Id).toBeUndefined();
+  });
+
+  it('type 43: nested events become MarketEvent with mapped markets and bets', () => {
+    const msg = plainToInstance(
+      OutrightLeagueSettlementUpdate,
+      { Competition: competitionPayload40 },
+      { excludeExtraneousValues: true },
+    );
+    const event = msg?.competition?.competitions?.[0]?.events?.[0];
+
+    expect(event).toBeInstanceOf(MarketEvent);
+    expect(event?.fixtureId).toBe(99);
+    expect(event?.markets?.[0]?.bets?.[0]?.id).toBe('2');
+  });
+});

--- a/test/entities/core-entities/utilities/transform-event-instance.spec.ts
+++ b/test/entities/core-entities/utilities/transform-event-instance.spec.ts
@@ -1,0 +1,32 @@
+import { MarketEvent } from '../../../../src/entities/core-entities/market/market-event';
+import { OutrightLeagueFixtureEvent } from '../../../../src/entities/core-entities/outright-league/outright-league-fixture-event';
+import { transformToEventInstance } from '../../../../src/entities/core-entities/utilities/transform-event-instance';
+
+describe('transformToEventInstance', () => {
+  it('maps OutrightLeague events to OutrightLeagueFixtureEvent instances', () => {
+    const result = transformToEventInstance([
+      { FixtureId: 1, OutrightLeague: { Status: 2 } },
+    ]) as OutrightLeagueFixtureEvent[];
+
+    expect(result[0]).toBeInstanceOf(OutrightLeagueFixtureEvent);
+    expect(result[0].fixtureId).toBe(1);
+  });
+
+  it('maps Markets events to MarketEvent instances with nested markets', () => {
+    const result = transformToEventInstance([
+      {
+        FixtureId: 2,
+        Markets: [{ Id: 10, Name: 'Winner', Bets: [{ Id: 20, Name: 'Home', Status: 1 }] }],
+      },
+    ]) as MarketEvent[];
+
+    expect(result[0]).toBeInstanceOf(MarketEvent);
+    expect(result[0].fixtureId).toBe(2);
+    expect(result[0].markets?.[0]?.id).toBe(10);
+    expect(result[0].markets?.[0]?.bets?.[0]?.id).toBe('20');
+  });
+
+  it('returns empty arrays unchanged', () => {
+    expect(transformToEventInstance([])).toEqual([]);
+  });
+});


### PR DESCRIPTION
# User description
- Resolved unstable deserialization of message types 38, 40, and 43 by removing circular imports and ensuring proper event type resolution.
- Added regression and unit tests to validate the changes.
- No breaking changes introduced, maintaining backward compatibility for existing consumers.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Resolve unstable nested outright league feed event deserialization by reworking <code>transformToEventInstance</code> to rebuild its class map at call time and by replacing barrel imports with direct module references inside the competition and fixture classes. Add regression and unit tests that cover message types 38, 40, and 43 to validate the new transformation logic.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/103?tool=ast&topic=Nested+event+tests>Nested event tests</a>
        </td><td>Add regression and unit suites that assert message types 38, 40, and 43 now yield camelCase <code>OutrightLeagueFixtureEvent</code>/<code>MarketEvent</code> instances instead of plain PascalCase objects.<details><summary>Modified files (2)</summary><ul><li>test/entities/core-entities/outright-league/nested-event-transform.spec.ts</li>
<li>test/entities/core-entities/utilities/transform-event-instance.spec.ts</li></ul></details><details><summary>Latest Contributors(1)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update to version 3.9....</td><td>May 23, 2026</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/103?tool=ast&topic=Outright+event+fix>Outright event fix</a>
        </td><td>Prevent circular imports and rehydrate nested outright league events by invoking <code>transformToEventInstance</code> with a runtime-built class map and updating the related competition/fixture classes to use direct module imports and new message-type entry points.<details><summary>Modified files (11)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li>
<li>src/entities/core-entities/market/market-event.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-competitions.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-fixture-event.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-fixture.ts</li>
<li>src/entities/core-entities/outright-sport/outright-competition.ts</li>
<li>src/entities/core-entities/outright-sport/outright-fixture-event.ts</li>
<li>src/entities/core-entities/outright-sport/outright-score-event.ts</li>
<li>src/entities/core-entities/utilities/transform-event-instance.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update to version 3.9....</td><td>May 23, 2026</td></tr>
<tr><td>PavelTemno</td><td>update versions</td><td>January 27, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/103?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>