### PR TITLE
Add NextFixtureStartTime to OutrightLeagueMarketUpdate (type 40).

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.7](#version-397)
 - [Version 3.9.6](#version-396)
 - [Version 3.9.5](#version-395)
 - [Version 3.9.4](#version-394)
@@ -27,6 +28,16 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.7
+
+Adds `NextFixtureStartTime` support on Outright League Market Update (type 40) messages (TR-22695).
+
+### Added
+
+- **`OutrightLeagueMarketCompetition`** — Competition type for type 40 messages with optional `nextFixtureStartTime` (`Competition.NextFixtureStartTime` in the feed payload).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.9.6",
+      "version": "3.9.7",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.6",
+  "version": "3.9.7",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/entities/core-entities/outright-league/index.ts
+++ b/src/entities/core-entities/outright-league/index.ts
@@ -1,2 +1,3 @@
 export * from './outright-league-competition';
+export * from './outright-league-market-competition';
 export * from './outright-league-fixture-event';

--- a/src/entities/core-entities/outright-league/outright-league-competition.ts
+++ b/src/entities/core-entities/outright-league/outright-league-competition.ts
@@ -1,9 +1,10 @@
-import { Expose, Type } from 'class-transformer';
+import { Exclude, Expose, Type } from 'class-transformer';
 
-import { BaseEntity } from '@entities';
+import { BaseEntity } from '../../message-types';
 
-import { OutrightLeagueCompetitions } from './outright-league-competitions';
+import { MarketEvent } from '../market/market-event';
 
+@Exclude()
 export class OutrightLeagueCompetition<TEvent extends BaseEntity> {
   @Expose({ name: 'Id' })
   id?: number;
@@ -15,6 +16,12 @@ export class OutrightLeagueCompetition<TEvent extends BaseEntity> {
   type?: number;
 
   @Expose({ name: 'Competitions' })
-  @Type(() => OutrightLeagueCompetitions)
-  competitions?: OutrightLeagueCompetitions<TEvent>[];
+  @Type(() => require('./outright-league-competitions').OutrightLeagueCompetitions)
+  competitions?: import('./outright-league-competitions').OutrightLeagueCompetitions<TEvent>[];
+}
+
+export class OutrightLeagueMarketCompetition extends OutrightLeagueCompetition<MarketEvent> {
+  @Expose({ name: 'NextFixtureStartTime' })
+  @Type(() => Date)
+  nextFixtureStartTime?: Date;
 }

--- a/src/entities/core-entities/outright-league/outright-league-market-competition.ts
+++ b/src/entities/core-entities/outright-league/outright-league-market-competition.ts
@@ -1,0 +1,1 @@
+export { OutrightLeagueMarketCompetition } from './outright-league-competition';

--- a/src/entities/message-types/outright-league-market-update.ts
+++ b/src/entities/message-types/outright-league-market-update.ts
@@ -1,7 +1,7 @@
 import { Expose, Type } from 'class-transformer';
 
 import { EntityKey } from '@lsports/decorators';
-import { MarketEvent, OutrightLeagueCompetition } from '@lsports/entities';
+import { OutrightLeagueMarketCompetition } from '@lsports/entities';
 
 import { BaseEntity } from './';
 
@@ -10,6 +10,6 @@ export class OutrightLeagueMarketUpdate implements BaseEntity {
   [key: string]: unknown;
 
   @Expose({ name: 'Competition' })
-  @Type(() => OutrightLeagueCompetition)
-  competition?: OutrightLeagueCompetition<MarketEvent>;
+  @Type(() => OutrightLeagueMarketCompetition)
+  competition?: OutrightLeagueMarketCompetition;
 }

--- a/test/entities/core-entities/outright-league/outright-league-market-competition.spec.ts
+++ b/test/entities/core-entities/outright-league/outright-league-market-competition.spec.ts
@@ -1,0 +1,22 @@
+import { plainToInstance } from 'class-transformer';
+import { OutrightLeagueMarketCompetition } from '../../../../src/entities/core-entities/outright-league/outright-league-market-competition';
+
+describe('OutrightLeagueMarketCompetition', () => {
+  it('should deserialize NextFixtureStartTime for type 40 market messages', (): void => {
+    const plain = {
+      Id: 67,
+      Name: 'League_67',
+      Type: 3,
+      NextFixtureStartTime: '2026-05-29T14:44:55Z',
+    };
+    const competition = plainToInstance(OutrightLeagueMarketCompetition, plain, {
+      excludeExtraneousValues: true,
+      exposeUnsetFields: false,
+    });
+    expect(competition).toBeInstanceOf(OutrightLeagueMarketCompetition);
+    expect(competition.id).toBe(67);
+    expect(competition.name).toBe('League_67');
+    expect(competition.type).toBe(3);
+    expect(competition.nextFixtureStartTime).toEqual(new Date('2026-05-29T14:44:55Z'));
+  });
+});

--- a/test/entities/message-types/outright-league-market-update.spec.ts
+++ b/test/entities/message-types/outright-league-market-update.spec.ts
@@ -1,0 +1,55 @@
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { plainToInstance } from 'class-transformer';
+
+import { MarketEvent, OutrightLeagueMarketCompetition } from '@lsports/entities';
+import { OutrightLeagueMarketUpdate } from '../../../src/entities/message-types/outright-league-market-update';
+import { TransformerUtil } from '../../../src/utilities/transformer-util';
+import { BaseEntity } from '../../../src/entities/message-types';
+
+describe('OutrightLeagueMarketUpdate (type 40)', () => {
+  const payload = JSON.parse(
+    readFileSync(
+      join(__dirname, '../../fixtures/outright-league-market-update-type40.json'),
+      'utf-8',
+    ),
+  );
+
+  it('should deserialize a full production payload including NextFixtureStartTime', (): void => {
+    const update = plainToInstance(OutrightLeagueMarketUpdate, payload, {
+      excludeExtraneousValues: true,
+    });
+
+    expect(update.competition).toBeInstanceOf(OutrightLeagueMarketCompetition);
+    expect(update.competition?.id).toBe(67);
+    expect(update.competition?.name).toBe('League_67');
+    expect(update.competition?.type).toBe(3);
+    expect(update.competition?.nextFixtureStartTime).toEqual(new Date('2026-05-29T14:44:55Z'));
+
+    const season = update.competition?.competitions?.[0];
+    expect(season?.id).toBe(2029);
+    expect(season?.name).toBe('Season_2029');
+    expect(season?.type).toBe(4);
+
+    const event = season?.events?.[0];
+    expect(event).toBeInstanceOf(MarketEvent);
+    expect(event?.fixtureId).toBe(26721036);
+
+    const market = event?.markets?.[0];
+    expect(market?.id).toBe(274);
+    expect(market?.name).toBe('Outright Winner');
+    expect(market?.bets).toHaveLength(2);
+    expect(market?.bets?.[0]?.id).toBe('2655634626721036');
+    expect(market?.bets?.[0]?.name).toBe('Not Simply Simon');
+    expect(market?.bets?.[0]?.participantId).toBe(51523593);
+    expect(market?.providerMarkets?.[0]?.id).toBe(8);
+    expect(market?.providerMarkets?.[0]?.name).toBe('Bet365');
+    expect(market?.providerMarkets?.[0]?.Bets?.[0]?.id).toBe('23362');
+  });
+
+  it('should deserialize NextFixtureStartTime via TransformerUtil like the feed consumer', (): void => {
+    const update = TransformerUtil.transform(payload as BaseEntity, OutrightLeagueMarketUpdate);
+
+    expect(update.competition?.nextFixtureStartTime).toEqual(new Date('2026-05-29T14:44:55Z'));
+  });
+});

--- a/test/fixtures/outright-league-market-update-type40.json
+++ b/test/fixtures/outright-league-market-update-type40.json
@@ -1,0 +1,72 @@
+{
+  "Competition": {
+    "Id": 67,
+    "Name": "League_67",
+    "Type": 3,
+    "NextFixtureStartTime": "2026-05-29T14:44:55Z",
+    "Competitions": [
+      {
+        "Id": 2029,
+        "Name": "Season_2029",
+        "Type": 4,
+        "Events": [
+          {
+            "FixtureId": 26721036,
+            "Livescore": null,
+            "Markets": [
+              {
+                "Id": 274,
+                "Name": "Outright Winner",
+                "Bets": [
+                  {
+                    "Probability": -1.0,
+                    "Id": 2655634626721036,
+                    "Name": "Not Simply Simon",
+                    "Status": 1,
+                    "StartPrice": "1.5",
+                    "Price": "1.5",
+                    "ProviderBetId": "8",
+                    "LastUpdate": "2026-05-27T17:44:59.54+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:59.540Z",
+                    "ParticipantId": 51523593
+                  },
+                  {
+                    "Probability": -1.0,
+                    "Id": 201914637926721036,
+                    "Name": "Ranger Annie",
+                    "Status": 1,
+                    "StartPrice": "2.5",
+                    "Price": "2.5",
+                    "ProviderBetId": "8",
+                    "LastUpdate": "2026-05-27T17:44:59.54+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:59.540Z",
+                    "ParticipantId": 51523594
+                  }
+                ],
+                "ProviderMarkets": [
+                  {
+                    "Id": 8,
+                    "Name": "Bet365",
+                    "LastUpdate": "2026-05-27T17:44:58.254+03:00",
+                    "SerializedLastUpdate": "2026-05-27T17:44:58.254Z",
+                    "Bets": [
+                      {
+                        "Id": 23362,
+                        "Name": "Not Simply Simon",
+                        "Status": 1,
+                        "StartPrice": "1.5",
+                        "Price": "1.5",
+                        "LastUpdate": "2026-05-27T17:44:55.579+03:00",
+                        "SerializedLastUpdate": "2026-05-27T17:44:55.579Z"
+                      }
+                    ]
+                  }
+                ]
+              }
+            ]
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
# User description
Introduce OutrightLeagueMarketCompetition for market-only feed messages and allow provider-market bets without Id while keeping Bet id validation strict.

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Update the <code>OutrightLeagueMarketCompetition</code> and <code>OutrightLeagueMarketUpdate</code> entities so type-40 feeds deserialize the optional <code>NextFixtureStartTime</code> field and expose it downstream. Document the release in the changelog and bump the package so SDK consumers can rely on the new payload support.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/105?tool=ast&topic=Type40+Market+Flow>Type40 Market Flow</a>
        </td><td>Implement the type-40 outright market flow by exporting <code>OutrightLeagueMarketCompetition</code>, extending <code>OutrightLeagueCompetition</code> with <code>NextFixtureStartTime</code>, wiring the new competition into <code>OutrightLeagueMarketUpdate</code>, and validating the full payload plus transformer behavior via fixtures and serializer tests.<details><summary>Modified files (7)</summary><ul><li>src/entities/core-entities/outright-league/index.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-competition.ts</li>
<li>src/entities/core-entities/outright-league/outright-league-market-competition.ts</li>
<li>src/entities/message-types/outright-league-market-update.ts</li>
<li>test/entities/core-entities/outright-league/outright-league-market-competition.spec.ts</li>
<li>test/entities/message-types/outright-league-market-update.spec.ts</li>
<li>test/fixtures/outright-league-market-update-type40.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TR-22695: Add NextFixt...</td><td>May 31, 2026</td></tr>
<tr><td>benny.h@lsports.eu</td><td>change entities inside...</td><td>September 22, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/105?tool=ast&topic=Release+%26+Docs>Release & Docs</a>
        </td><td>Record the SDK version bump and release notes for adding <code>NextFixtureStartTime</code> support so downstream consumers know to upgrade.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TR-22695: Add NextFixt...</td><td>May 31, 2026</td></tr>
<tr><td>PavelTemno</td><td>update versions</td><td>January 27, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/105?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>