### PR TITLE
TRGN-3848: Add MarketId to TransportMessageHeaders (v3.9.8)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.9.8](#version-398)
 - [Version 3.9.7](#version-397)
 - [Version 3.9.6](#version-396)
 - [Version 3.9.5](#version-395)
@@ -28,6 +29,16 @@ All notable changes to this project will be documented in this file.
 - [Version 3.0.0](#version-300)
 - [Version 2.0.1](#version-201)
 
+
+---
+
+## Version 3.9.8
+
+Adds optional `MarketId` customer message header support (TRGN-3848).
+
+### Added
+
+- **`TransportMessageHeaders`**: optional `marketId` customer message header (`MarketId`, TRGN-3848).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.9.7",
+      "version": "3.9.8",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.9.7",
+  "version": "3.9.8",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/sample/feed-sample/package-lock.json
+++ b/sample/feed-sample/package-lock.json
@@ -22,7 +22,7 @@
       }
     },
     "../..": {
-      "version": "3.9.2",
+      "version": "3.9.8",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/sample/feed-sample/src/handler/inplay/market-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/market-update.handler.ts
@@ -7,6 +7,7 @@ export class MarketUpdateHandler implements IEntityHandler<MarketUpdate> {
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/outright-league-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/outright-league-market-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/outright-league-settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/outright-league-settlement-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueSettlementUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/inplay/settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/settlement-update.handler.ts
@@ -7,6 +7,7 @@ export class SettlementUpdateHandler implements IEntityHandler<SettlementUpdate>
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/ouright-settlements-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/ouright-settlements-update.handler.ts
@@ -11,6 +11,7 @@ export class OutrightSettlementsUpdateHandler implements IEntityHandler<Outright
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-fixture-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-fixture-market-update.handler.ts
@@ -17,6 +17,7 @@ export class OutrightFixtureMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-league-market-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-league-market-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueMarketUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/sample/feed-sample/src/handler/prematch/outright-league-settlement-update.handler.ts
+++ b/sample/feed-sample/src/handler/prematch/outright-league-settlement-update.handler.ts
@@ -13,6 +13,7 @@ export class OutrightLeagueSettlementUpdateHandler
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       fixtureId: transportHeaders.fixtureId,
+      marketId: transportHeaders.marketId,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });

--- a/src/entities/message-wrappers/transport-message-headers.ts
+++ b/src/entities/message-wrappers/transport-message-headers.ts
@@ -9,6 +9,8 @@ export class TransportMessageHeaders {
 
   private static readonly FIXTURE_ID_KEY = 'FixtureId';
 
+  private static readonly MARKET_ID_KEY = 'MarketId';
+
   private static readonly SPORT_ID_KEY = 'SportId';
 
   private static readonly ALLOWED_KEYS = new Set([
@@ -17,6 +19,7 @@ export class TransportMessageHeaders {
     TransportMessageHeaders.TIMESTAMP_IN_MS_KEY,
     TransportMessageHeaders.MESSAGE_SEQUENCE_KEY,
     TransportMessageHeaders.FIXTURE_ID_KEY,
+    TransportMessageHeaders.MARKET_ID_KEY,
     TransportMessageHeaders.SPORT_ID_KEY,
   ]);
 
@@ -27,6 +30,8 @@ export class TransportMessageHeaders {
   public messageGuid!: string;
 
   public fixtureId!: string;
+
+  public marketId!: string;
 
   public sportId!: string;
 
@@ -47,6 +52,7 @@ export class TransportMessageHeaders {
       false,
     );
     headers.fixtureId = this.getRequiredProperty(properties, this.FIXTURE_ID_KEY, false);
+    headers.marketId = this.getRequiredProperty(properties, this.MARKET_ID_KEY, false);
     headers.sportId = this.getRequiredProperty(properties, this.SPORT_ID_KEY, false);
 
     return headers;

--- a/test/entities/message-wrappers/transport-message-headers.spec.ts
+++ b/test/entities/message-wrappers/transport-message-headers.spec.ts
@@ -9,6 +9,7 @@ describe('TransportMessageHeaders', () => {
         timestamp_in_ms: '1640995200000',
         MessageSequence: 'seq-456',
         FixtureId: 'fixture-789',
+        MarketId: 'market-202',
         SportId: 'sport-101',
       };
 
@@ -19,6 +20,7 @@ describe('TransportMessageHeaders', () => {
       expect(headers.timestampInMs).toBe('1640995200000');
       expect(headers.messageSequence).toBe('seq-456');
       expect(headers.fixtureId).toBe('fixture-789');
+      expect(headers.marketId).toBe('market-202');
       expect(headers.sportId).toBe('sport-101');
     });
 
@@ -36,6 +38,7 @@ describe('TransportMessageHeaders', () => {
       expect(headers.timestampInMs).toBe('1640995200000');
       expect(headers.messageSequence).toBe('');
       expect(headers.fixtureId).toBe('');
+      expect(headers.marketId).toBe('');
       expect(headers.sportId).toBe('');
     });
 
@@ -157,6 +160,7 @@ describe('TransportMessageHeaders', () => {
         timestamp_in_ms: '1640995200000',
         MessageSequence: null,
         FixtureId: undefined,
+        MarketId: null,
         SportId: null,
       };
 
@@ -164,6 +168,7 @@ describe('TransportMessageHeaders', () => {
 
       expect(headers.messageSequence).toBe('');
       expect(headers.fixtureId).toBe('');
+      expect(headers.marketId).toBe('');
       expect(headers.sportId).toBe('');
     });
 
@@ -189,6 +194,7 @@ describe('TransportMessageHeaders', () => {
         timestamp_in_ms: 1640995200000,
         MessageSequence: null,
         FixtureId: Buffer.from('fixture-789', 'utf8'),
+        MarketId: Buffer.from('market-202', 'utf8'),
         SportId: Buffer.from('sport-456', 'utf8'),
       };
 
@@ -199,6 +205,7 @@ describe('TransportMessageHeaders', () => {
       expect(headers.timestampInMs).toBe('1640995200000');
       expect(headers.messageSequence).toBe('');
       expect(headers.fixtureId).toBe('fixture-789');
+      expect(headers.marketId).toBe('market-202');
       expect(headers.sportId).toBe('sport-456');
     });
 


### PR DESCRIPTION
# User description
## Summary
- Add optional `MarketId` customer message header to `TransportMessageHeaders`, mirroring existing `FixtureId` / `SportId` support
- Bump package version to **3.9.8** and update changelog

Linear: https://linear.app/lsports-ltd/issue/TRGN-3848/add-marketid-to-sdks-part-of-customer-message-headers

## Test plan
- [x] `npm test -- --testPathPattern=transport-message-headers` (20/20 passing)
- [ ] CI green on PR

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>MarketId</code> customer message header handling by wiring it through <code>TransportMessageHeaders</code> and the sample feed handlers so incoming metadata mirrors FixtureId/SportId support. Document the 3.9.8 release and package version to reflect the new MarketId capability.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/107?tool=ast&topic=MarketId+headers>MarketId headers</a>
        </td><td>Add optional <code>marketId</code> field to <code>TransportMessageHeaders</code>, extend the property mapping and unit tests, and pass the value through the sample feed handlers so message metadata exposes MarketId.<details><summary>Modified files (10)</summary><ul><li>sample/feed-sample/src/handler/inplay/market-update.handler.ts</li>
<li>sample/feed-sample/src/handler/inplay/outright-league-market-update.handler.ts</li>
<li>sample/feed-sample/src/handler/inplay/outright-league-settlement-update.handler.ts</li>
<li>sample/feed-sample/src/handler/inplay/settlement-update.handler.ts</li>
<li>sample/feed-sample/src/handler/prematch/ouright-settlements-update.handler.ts</li>
<li>sample/feed-sample/src/handler/prematch/outright-fixture-market-update.handler.ts</li>
<li>sample/feed-sample/src/handler/prematch/outright-league-market-update.handler.ts</li>
<li>sample/feed-sample/src/handler/prematch/outright-league-settlement-update.handler.ts</li>
<li>src/entities/message-wrappers/transport-message-headers.ts</li>
<li>test/entities/message-wrappers/transport-message-headers.spec.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>Update package-lock.js...</td><td>June 14, 2026</td></tr>
<tr><td>noam.m@lsports.eu</td><td>Feature tr 18311 expos...</td><td>August 27, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/107?tool=ast&topic=Release+updates>Release updates</a>
        </td><td>Document the 3.9.8 release by updating package metadata and the changelog for the MarketId header addition.<details><summary>Modified files (4)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li>
<li>sample/feed-sample/package-lock.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>TRGN-3848: Add MarketI...</td><td>June 14, 2026</td></tr>
<tr><td>PavelTemno</td><td>update versions</td><td>January 27, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/107?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>