### PR TITLE
PRD-1516: Add PredictionData to market entities (v3.10.4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.10.5](#version-3105)
 - [Version 3.10.4](#version-3104)
 - [Version 3.10.3](#version-3103)
 - [Version 3.10.1](#version-3101)
@@ -37,6 +38,17 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## [Unreleased]
+
+---
+
+## Version 3.10.5
+
+Splits unified `PredictionData` into market- and bet-specific types (PRD-1516).
+
+### Changed
+
+- **`MarketPredictionData`**: volume-only type on `Market` and `ProviderMarket` (JSON field `PredictionData`).
+- **`BetPredictionData`**: full type with `volume`, `liquidity`, `startDate`, and `endDate` on `BaseBet` (JSON field `PredictionData`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.10.4](#version-3104)
 - [Version 3.10.3](#version-3103)
 - [Version 3.10.1](#version-3101)
 - [Version 3.10.0](#version-3100)
@@ -37,9 +38,15 @@ All notable changes to this project will be documented in this file.
 
 ## [Unreleased]
 
-### Changed
+---
 
-- **`Market.status`**: RMQ JSON field is `Status` on calculated market payloads (PRD-1516). No property rename from 3.10.1.
+## Version 3.10.4
+
+Adds DI `PredictionData` on market and bet entities (PRD-1516).
+
+### Added
+
+- **`PredictionData`**: optional `volume`, `liquidity`, `startDate`, and `endDate` on `Market`, `ProviderMarket`, and `BaseBet` (JSON field `PredictionData`).
 
 ---
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,6 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
-- [Version 3.10.5](#version-3105)
 - [Version 3.10.4](#version-3104)
 - [Version 3.10.3](#version-3103)
 - [Version 3.10.1](#version-3101)
@@ -41,24 +40,14 @@ All notable changes to this project will be documented in this file.
 
 ---
 
-## Version 3.10.5
-
-Splits unified `PredictionData` into market- and bet-specific types (PRD-1516).
-
-### Changed
-
-- **`MarketPredictionData`**: volume-only type on `Market` and `ProviderMarket` (JSON field `PredictionData`).
-- **`BetPredictionData`**: full type with `volume`, `liquidity`, `startDate`, and `endDate` on `BaseBet` (JSON field `PredictionData`).
-
----
-
 ## Version 3.10.4
 
-Adds DI `PredictionData` on market and bet entities (PRD-1516).
+Adds DI prediction metadata on market and bet entities (PRD-1516).
 
 ### Added
 
-- **`PredictionData`**: optional `volume`, `liquidity`, `startDate`, and `endDate` on `Market`, `ProviderMarket`, and `BaseBet` (JSON field `PredictionData`).
+- **`MarketPredictionData`**: volume-only type on `Market` and `ProviderMarket` (JSON field `PredictionData`).
+- **`BetPredictionData`**: full type with `volume`, `liquidity`, `startDate`, and `endDate` on `BaseBet` (JSON field `PredictionData`).
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.5",
+  "version": "3.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.10.5",
+      "version": "3.10.4",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.10.4",
+      "version": "3.10.5",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.10.3",
+      "version": "3.10.4",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.5",
+  "version": "3.10.4",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.3",
+  "version": "3.10.4",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/entities/core-entities/market/base-bet.ts
+++ b/src/entities/core-entities/market/base-bet.ts
@@ -2,7 +2,7 @@ import { Expose, Type, Transform } from 'class-transformer';
 
 import { BetStatus, SettlementType } from '@lsports/enums';
 import { IdTransformerUtil } from '../../../utilities/id-transformer-util';
-import { PredictionData } from './prediction-data';
+import { BetPredictionData } from './bet-prediction-data';
 
 /**
  * Base betting entity with string-based ID handling for JSON compatibility.
@@ -85,6 +85,6 @@ export class BaseBet {
   order?: number;
 
   @Expose({ name: 'PredictionData' })
-  @Type(() => PredictionData)
-  predictionData?: PredictionData;
+  @Type(() => BetPredictionData)
+  predictionData?: BetPredictionData;
 }

--- a/src/entities/core-entities/market/base-bet.ts
+++ b/src/entities/core-entities/market/base-bet.ts
@@ -2,6 +2,7 @@ import { Expose, Type, Transform } from 'class-transformer';
 
 import { BetStatus, SettlementType } from '@lsports/enums';
 import { IdTransformerUtil } from '../../../utilities/id-transformer-util';
+import { PredictionData } from './prediction-data';
 
 /**
  * Base betting entity with string-based ID handling for JSON compatibility.
@@ -82,4 +83,8 @@ export class BaseBet {
 
   @Expose({ name: 'Order' })
   order?: number;
+
+  @Expose({ name: 'PredictionData' })
+  @Type(() => PredictionData)
+  predictionData?: PredictionData;
 }

--- a/src/entities/core-entities/market/bet-prediction-data.ts
+++ b/src/entities/core-entities/market/bet-prediction-data.ts
@@ -1,6 +1,6 @@
 import { Expose, Type } from 'class-transformer';
 
-export class PredictionData {
+export class BetPredictionData {
   @Expose({ name: 'Volume' })
   volume?: number;
 

--- a/src/entities/core-entities/market/index.ts
+++ b/src/entities/core-entities/market/index.ts
@@ -6,3 +6,4 @@ export * from './base-bet';
 export * from './provider-bet';
 export * from './provider-market';
 export * from './provider';
+export * from './prediction-data';

--- a/src/entities/core-entities/market/index.ts
+++ b/src/entities/core-entities/market/index.ts
@@ -6,4 +6,5 @@ export * from './base-bet';
 export * from './provider-bet';
 export * from './provider-market';
 export * from './provider';
-export * from './prediction-data';
+export * from './market-prediction-data';
+export * from './bet-prediction-data';

--- a/src/entities/core-entities/market/market-prediction-data.ts
+++ b/src/entities/core-entities/market/market-prediction-data.ts
@@ -1,0 +1,6 @@
+import { Expose } from 'class-transformer';
+
+export class MarketPredictionData {
+  @Expose({ name: 'Volume' })
+  volume?: number;
+}

--- a/src/entities/core-entities/market/market.ts
+++ b/src/entities/core-entities/market/market.ts
@@ -3,7 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { Bet } from './bet';
 import { MarketStatus } from './market-status';
 import { ProviderMarket } from './provider-market';
-import { PredictionData } from './prediction-data';
+import { MarketPredictionData } from './market-prediction-data';
 
 export class Market {
   @Expose({ name: 'Id' })
@@ -27,6 +27,6 @@ export class Market {
   status?: MarketStatus;
 
   @Expose({ name: 'PredictionData' })
-  @Type(() => PredictionData)
-  predictionData?: PredictionData;
+  @Type(() => MarketPredictionData)
+  predictionData?: MarketPredictionData;
 }

--- a/src/entities/core-entities/market/market.ts
+++ b/src/entities/core-entities/market/market.ts
@@ -3,6 +3,7 @@ import { Expose, Type } from 'class-transformer';
 import { Bet } from './bet';
 import { MarketStatus } from './market-status';
 import { ProviderMarket } from './provider-market';
+import { PredictionData } from './prediction-data';
 
 export class Market {
   @Expose({ name: 'Id' })
@@ -24,4 +25,8 @@ export class Market {
 
   @Expose({ name: 'Status' })
   status?: MarketStatus;
+
+  @Expose({ name: 'PredictionData' })
+  @Type(() => PredictionData)
+  predictionData?: PredictionData;
 }

--- a/src/entities/core-entities/market/prediction-data.ts
+++ b/src/entities/core-entities/market/prediction-data.ts
@@ -1,0 +1,17 @@
+import { Expose, Type } from 'class-transformer';
+
+export class PredictionData {
+  @Expose({ name: 'Volume' })
+  volume?: number;
+
+  @Expose({ name: 'Liquidity' })
+  liquidity?: number;
+
+  @Expose({ name: 'StartDate' })
+  @Type(() => Date)
+  startDate?: Date;
+
+  @Expose({ name: 'EndDate' })
+  @Type(() => Date)
+  endDate?: Date;
+}

--- a/src/entities/core-entities/market/provider-market.ts
+++ b/src/entities/core-entities/market/provider-market.ts
@@ -2,6 +2,7 @@ import { Expose, Type } from 'class-transformer';
 
 import { ProviderBet } from './provider-bet';
 import { MarketStatus } from './market-status';
+import { PredictionData } from './prediction-data';
 
 export class ProviderMarket {
   @Expose({ name: 'Id' })
@@ -20,4 +21,8 @@ export class ProviderMarket {
 
   @Expose({ name: 'MarketStatus' })
   marketStatus?: MarketStatus;
+
+  @Expose({ name: 'PredictionData' })
+  @Type(() => PredictionData)
+  predictionData?: PredictionData;
 }

--- a/src/entities/core-entities/market/provider-market.ts
+++ b/src/entities/core-entities/market/provider-market.ts
@@ -2,7 +2,7 @@ import { Expose, Type } from 'class-transformer';
 
 import { ProviderBet } from './provider-bet';
 import { MarketStatus } from './market-status';
-import { PredictionData } from './prediction-data';
+import { MarketPredictionData } from './market-prediction-data';
 
 export class ProviderMarket {
   @Expose({ name: 'Id' })
@@ -23,6 +23,6 @@ export class ProviderMarket {
   marketStatus?: MarketStatus;
 
   @Expose({ name: 'PredictionData' })
-  @Type(() => PredictionData)
-  predictionData?: PredictionData;
+  @Type(() => MarketPredictionData)
+  predictionData?: MarketPredictionData;
 }

--- a/test/entities/core-entities/fixture/fixture.spec.ts
+++ b/test/entities/core-entities/fixture/fixture.spec.ts
@@ -49,6 +49,16 @@ describe('Fixture Entity', () => {
     expect(fixture.season?.name).toBe('2024-2025');
   });
 
+  it('should deserialize Rules fixture extra data', (): void => {
+    const rulesText = 'Match consists of two halves of 45 minutes each.';
+    const plain = {
+      FixtureExtraData: [{ Name: 'Rules', Value: rulesText }],
+    };
+    const fixture = plainToInstance(Fixture, plain, { excludeExtraneousValues: true });
+    expect(fixture.fixtureExtraData?.[0].name).toBe('Rules');
+    expect(fixture.fixtureExtraData?.[0].value).toBe(rulesText);
+  });
+
   it('should handle missing optional properties', (): void => {
     const plain = {
       Sport: { id: 2, name: 'Football' },

--- a/test/entities/core-entities/market/base-bet.spec.ts
+++ b/test/entities/core-entities/market/base-bet.spec.ts
@@ -438,4 +438,21 @@ describe('BaseBet Entity', () => {
     expect(baseBet.baseLine).toBeUndefined();
     expect(baseBet.suspensionReason).toBeUndefined();
   });
+
+  it('should deserialize PredictionData on bet', (): void => {
+    const plain = {
+      Id: '1',
+      PredictionData: {
+        Volume: 2529.72,
+        Liquidity: 0,
+        StartDate: '2026-01-15T10:00:00.000Z',
+        EndDate: '2026-01-15T12:00:00.000Z',
+      },
+    };
+    const baseBet = plainToInstance(BaseBet, plain, { excludeExtraneousValues: true });
+    expect(baseBet.predictionData?.volume).toBe(2529.72);
+    expect(baseBet.predictionData?.liquidity).toBe(0);
+    expect(baseBet.predictionData?.startDate).toBeInstanceOf(Date);
+    expect(baseBet.predictionData?.endDate).toBeInstanceOf(Date);
+  });
 });

--- a/test/entities/core-entities/market/base-bet.spec.ts
+++ b/test/entities/core-entities/market/base-bet.spec.ts
@@ -439,7 +439,7 @@ describe('BaseBet Entity', () => {
     expect(baseBet.suspensionReason).toBeUndefined();
   });
 
-  it('should deserialize PredictionData on bet', (): void => {
+  it('should deserialize BetPredictionData on bet', (): void => {
     const plain = {
       Id: '1',
       PredictionData: {


### PR DESCRIPTION
## Summary

- Adds `MarketPredictionData` on `Market` and `ProviderMarket`, and `BetPredictionData` on `BaseBet`.
- Bumps package version to **3.10.4** (single release).
- Part of PRD-1516 PredictionData end-to-end flow.

## Test plan

- [x] `npm test` — 646 tests pass locally