### PR TITLE
FIH Phase 1: HeartbeatUpdate feedInterrupted number[]

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.10.5](#version-3105)
 - [Version 3.10.4](#version-3104)
 - [Version 3.10.3](#version-3103)
 - [Version 3.10.1](#version-3101)
@@ -37,6 +38,16 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## [Unreleased]
+
+---
+
+## Version 3.10.5
+
+Exposes feed interruption signal on heartbeat updates (TRGN-3934).
+
+### Added
+
+- **`HeartbeatUpdate.feedInterrupted`**: optional feed interruption signal on type-32 heartbeat body (`undefined`/absent = normal, non-zero = interrupted). Maps JSON field `FeedInterrupted`. Signal only — does not trigger auto-suspend or recovery.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.10.4",
+      "version": "3.10.5",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.4",
+  "version": "3.10.5",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/sample/feed-sample/src/handler/inplay/heartbeat-update.handler.ts
+++ b/sample/feed-sample/src/handler/inplay/heartbeat-update.handler.ts
@@ -1,15 +1,18 @@
 import { IEntityHandler, HeartbeatUpdate, IMessageStructure } from 'trade360-nodejs-sdk';
 
 export class HeartbeatUpdateHandler implements IEntityHandler<HeartbeatUpdate> {
+  constructor(private readonly marketLabel: string = 'unknown') {}
+
   public processAsync = async ({ header, entity, transportHeaders }: IMessageStructure<HeartbeatUpdate>) => {
-    console.log('HeartbeatUpdate received!');
+    console.log(
+      `[FIH] HeartbeatUpdate ${this.marketLabel}: feedInterrupted=${entity?.feedInterrupted ?? 'undefined/absent'} (absent/0=normal, non-zero=interrupted)`,
+    );
     console.log('Transport Headers:', {
       messageGuid: transportHeaders.messageGuid,
       messageType: transportHeaders.messageType,
       timestampInMs: transportHeaders.timestampInMs,
       messageSequence: transportHeaders.messageSequence,
     });
-    console.log(entity);
     return;
   };
 }

--- a/sample/feed-sample/src/index.ts
+++ b/sample/feed-sample/src/index.ts
@@ -63,7 +63,7 @@ const initSample = async () => {
     feedInPlay.addEntityHandler(new LivescoreUpdateHandler(), LivescoreUpdate);
     feedInPlay.addEntityHandler(new MarketUpdateHandler(), MarketUpdate);
     feedInPlay.addEntityHandler(new SettlementUpdateHandler(), SettlementUpdate);
-    feedInPlay.addEntityHandler(new HeartbeatUpdateHandler(), HeartbeatUpdate);
+    feedInPlay.addEntityHandler(new HeartbeatUpdateHandler('InPlay'), HeartbeatUpdate);
     feedInPlay.addEntityHandler(new KeepAliveUpdateHandler(), KeepAliveUpdate);
     feedInPlay.addEntityHandler(new OutrightLeagueFixtureUpdateHandler(),OutrightLeagueFixtureUpdate);
     feedInPlay.addEntityHandler(new OutrightLeagueMarketUpdateHandler(), OutrightLeagueMarketUpdate);
@@ -77,7 +77,7 @@ const initSample = async () => {
     feedPreMatch.addEntityHandler(new OutrightScoreUpdateHandler(), OutrightScoreUpdate);
     feedPreMatch.addEntityHandler(new OutrightFixtureMarketUpdateHandler(),OutrightFixtureMarketUpdate);
     feedPreMatch.addEntityHandler(new OutrightSettlementsUpdateHandler(), OutrightSettlementsUpdate);
-    feedPreMatch.addEntityHandler(new HeartbeatUpdateHandler(), HeartbeatUpdate);
+    feedPreMatch.addEntityHandler(new HeartbeatUpdateHandler('PreMatch'), HeartbeatUpdate);
     feedPreMatch.addEntityHandler(new OutrightLeagueFixtureUpdateHandler(),OutrightLeagueFixtureUpdate);
     feedPreMatch.addEntityHandler(new OutrightLeagueMarketUpdateHandler(), OutrightLeagueMarketUpdate);
     feedPreMatch.addEntityHandler(new OutrightLeagueSettlementUpdateHandler(), OutrightLeagueSettlementUpdate);
@@ -92,13 +92,23 @@ const initSample = async () => {
     process.on('SIGINT', shutdown);
     process.on('exit', shutdown);
 
-    await feedInPlay.start(true);
-    await feedPreMatch.start(true);
+    // FIH_IP_ONLY=1 / FIH_PM_ONLY=1 for single-product live checks.
+    if (process.env.FIH_PM_ONLY !== '1') {
+      await feedInPlay.start(true);
+    } else {
+      logger.info('[FIH] InPlay skipped (FIH_PM_ONLY=1)');
+    }
+    if (process.env.FIH_IP_ONLY !== '1') {
+      await feedPreMatch.start(true);
+    } else {
+      logger.info('[FIH] PreMatch skipped (FIH_IP_ONLY=1)');
+    }
 
+    const runMs = Number(process.env.FIH_RUN_SECONDS || 60) * 1000;
     await new Promise<void>((resolve) => {
       setTimeout(() => {
         return resolve();
-      }, 60 * 1000);
+      }, runMs);
     });
     shutdown();
     

--- a/src/entities/message-types/heartbeat-update.ts
+++ b/src/entities/message-types/heartbeat-update.ts
@@ -1,3 +1,5 @@
+import { Expose } from 'class-transformer';
+
 import { EntityKey } from '@lsports/decorators';
 
 import { BaseEntity } from './';
@@ -5,4 +7,11 @@ import { BaseEntity } from './';
 @EntityKey(32)
 export class HeartbeatUpdate implements BaseEntity {
   [key: string]: unknown;
+
+  /**
+   * Feed health signal. `undefined`/absent means no problem, non-zero indicates a
+   * problem detected upstream. Signal only — does not trigger auto-suspend or recovery.
+   */
+  @Expose({ name: 'Problem' })
+  public problem?: number;
 }

--- a/src/entities/message-types/heartbeat-update.ts
+++ b/src/entities/message-types/heartbeat-update.ts
@@ -9,9 +9,9 @@ export class HeartbeatUpdate implements BaseEntity {
   [key: string]: unknown;
 
   /**
-   * Feed interruption signal. `undefined`/absent means normal, non-zero indicates a
-   * feed interruption detected upstream. Signal only — does not trigger auto-suspend or recovery.
+   * Feed interruption domains. Empty/absent = healthy. Phase 1: `[1]` = Markets.
+   * Signal only — does not trigger auto-suspend or recovery.
    */
   @Expose({ name: 'FeedInterrupted' })
-  public feedInterrupted?: number;
+  public feedInterrupted?: number[];
 }

--- a/src/entities/message-types/heartbeat-update.ts
+++ b/src/entities/message-types/heartbeat-update.ts
@@ -9,9 +9,9 @@ export class HeartbeatUpdate implements BaseEntity {
   [key: string]: unknown;
 
   /**
-   * Feed health signal. `undefined`/absent means no problem, non-zero indicates a
-   * problem detected upstream. Signal only — does not trigger auto-suspend or recovery.
+   * Feed interruption signal. `undefined`/absent means normal, non-zero indicates a
+   * feed interruption detected upstream. Signal only — does not trigger auto-suspend or recovery.
    */
-  @Expose({ name: 'Problem' })
-  public problem?: number;
+  @Expose({ name: 'FeedInterrupted' })
+  public feedInterrupted?: number;
 }

--- a/test/entities/message-types/heartbeat-update.spec.ts
+++ b/test/entities/message-types/heartbeat-update.spec.ts
@@ -3,14 +3,14 @@ import { plainToInstance } from 'class-transformer';
 import { HeartbeatUpdate } from '../../../src/entities/message-types';
 
 describe('HeartbeatUpdate', () => {
-  it('should deserialize FeedInterrupted from the message body', (): void => {
-    const body = { FeedInterrupted: 1 };
+  it('should deserialize FeedInterrupted domain array from the message body', (): void => {
+    const body = { FeedInterrupted: [1] };
 
     const update = plainToInstance(HeartbeatUpdate, body, {
       excludeExtraneousValues: true,
     });
 
-    expect(update.feedInterrupted).toBe(1);
+    expect(update.feedInterrupted).toEqual([1]);
   });
 
   it('should leave feedInterrupted undefined when absent from the body', (): void => {

--- a/test/entities/message-types/heartbeat-update.spec.ts
+++ b/test/entities/message-types/heartbeat-update.spec.ts
@@ -1,0 +1,25 @@
+import { plainToInstance } from 'class-transformer';
+
+import { HeartbeatUpdate } from '../../../src/entities/message-types';
+
+describe('HeartbeatUpdate', () => {
+  it('should deserialize Problem from the message body', (): void => {
+    const body = { Problem: 1 };
+
+    const update = plainToInstance(HeartbeatUpdate, body, {
+      excludeExtraneousValues: true,
+    });
+
+    expect(update.problem).toBe(1);
+  });
+
+  it('should leave problem undefined when absent from the body', (): void => {
+    const body = {};
+
+    const update = plainToInstance(HeartbeatUpdate, body, {
+      excludeExtraneousValues: true,
+    });
+
+    expect(update.problem).toBeUndefined();
+  });
+});

--- a/test/entities/message-types/heartbeat-update.spec.ts
+++ b/test/entities/message-types/heartbeat-update.spec.ts
@@ -3,23 +3,23 @@ import { plainToInstance } from 'class-transformer';
 import { HeartbeatUpdate } from '../../../src/entities/message-types';
 
 describe('HeartbeatUpdate', () => {
-  it('should deserialize Problem from the message body', (): void => {
-    const body = { Problem: 1 };
+  it('should deserialize FeedInterrupted from the message body', (): void => {
+    const body = { FeedInterrupted: 1 };
 
     const update = plainToInstance(HeartbeatUpdate, body, {
       excludeExtraneousValues: true,
     });
 
-    expect(update.problem).toBe(1);
+    expect(update.feedInterrupted).toBe(1);
   });
 
-  it('should leave problem undefined when absent from the body', (): void => {
+  it('should leave feedInterrupted undefined when absent from the body', (): void => {
     const body = {};
 
     const update = plainToInstance(HeartbeatUpdate, body, {
       excludeExtraneousValues: true,
     });
 
-    expect(update.problem).toBeUndefined();
+    expect(update.feedInterrupted).toBeUndefined();
   });
 });


### PR DESCRIPTION
# User description
## Summary
- feedInterrupted: number → number[]\n- Absent/empty = healthy\n- Unit + sample handler updated

## Test plan
- [x] FIH unit tests pass locally (where SDK available)
- [ ] CI green

Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Expose <code>HeartbeatUpdate.feedInterrupted</code> as an optional <code>number[]</code> so the SDK can surface the new heartbeat feed interruption signal without changing recovery behavior. Update the sample <code>HeartbeatUpdateHandler</code> and feed bootstrap to print the signal and support isolated InPlay/PreMatch checks.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/115?tool=ast&topic=Sample+flow>Sample flow</a>
        </td><td>Update the sample heartbeat consumer to log the new interruption data, tag each feed, and allow running InPlay or PreMatch independently through environment flags.<details><summary>Modified files (4)</summary><ul><li>sample/feed-sample/src/handler/inplay/heartbeat-update.handler.ts</li>
<li>sample/feed-sample/src/handler/inplay/heartbeat-update.handler.ts</li>
<li>sample/feed-sample/src/index.ts</li>
<li>sample/feed-sample/src/index.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gal.be@lsports.eu</td><td>FIH Phase 1: Heartbeat...</td><td>August 03, 2026</td></tr>
<tr><td>shir.b@lsports.eu</td><td>Add Outright League Ha...</td><td>November 19, 2025</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/115?tool=ast&topic=Heartbeat+model>Heartbeat model</a>
        </td><td>Expose <code>HeartbeatUpdate.feedInterrupted</code> by mapping <code>FeedInterrupted</code> into the heartbeat entity, adding deserialization tests, and documenting/versioning the new SDK release.<details><summary>Modified files (10)</summary><ul><li>CHANGELOG.md</li>
<li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package-lock.json</li>
<li>package.json</li>
<li>package.json</li>
<li>src/entities/message-types/heartbeat-update.ts</li>
<li>src/entities/message-types/heartbeat-update.ts</li>
<li>test/entities/message-types/heartbeat-update.spec.ts</li>
<li>test/entities/message-types/heartbeat-update.spec.ts</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>gal.be@lsports.eu</td><td>Expose feedInterrupted...</td><td>July 28, 2026</td></tr>
<tr><td>ortal@lsports.eu</td><td>Consolidate Prediction...</td><td>July 22, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/115?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>