### PR TITLE
feat: add FixtureName to MarketEvent for types 40/43 (TRGN-1739)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 
 ## Table of Contents
 
+- [Version 3.10.6](#version-3106)
 - [Version 3.10.5](#version-3105)
 - [Version 3.10.4](#version-3104)
 - [Version 3.10.3](#version-3103)
@@ -38,6 +39,16 @@ All notable changes to this project will be documented in this file.
 ---
 
 ## [Unreleased]
+
+---
+
+## Version 3.10.6
+
+Adds optional fixture name on OutrightLeague market and settlement nested events (TRGN-1739).
+
+### Added
+
+- **`MarketEvent.fixtureName`**: optional fixture name on nested events in OutrightLeagueMarketUpdate (type 40) and OutrightLeagueSettlementUpdate (type 43). Maps JSON field `FixtureName`; omitted when absent from the payload.
 
 ---
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "trade360-nodejs-sdk",
-      "version": "3.10.5",
+      "version": "3.10.6",
       "license": "ISC",
       "dependencies": {
         "amqplib": "^0.10.4",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "trade360-nodejs-sdk",
-  "version": "3.10.5",
+  "version": "3.10.6",
   "description": "LSports Trade360 SDK for Node.js",
   "main": "dist/src/index.js",
   "types": "dist/src/index.d.ts",

--- a/src/entities/core-entities/market/market-event.ts
+++ b/src/entities/core-entities/market/market-event.ts
@@ -1,4 +1,4 @@
-import { Expose, Type } from 'class-transformer';
+import { Expose, Transform, Type } from 'class-transformer';
 
 import { BaseEntity } from '../../message-types';
 
@@ -11,6 +11,7 @@ export class MarketEvent implements BaseEntity {
   fixtureId!: number;
 
   @Expose({ name: 'FixtureName' })
+  @Transform(({ value }) => (value === null || value === '' ? undefined : value))
   fixtureName?: string;
 
   @Expose({ name: 'Markets' })

--- a/src/entities/core-entities/market/market-event.ts
+++ b/src/entities/core-entities/market/market-event.ts
@@ -10,6 +10,9 @@ export class MarketEvent implements BaseEntity {
   @Expose({ name: 'FixtureId' })
   fixtureId!: number;
 
+  @Expose({ name: 'FixtureName' })
+  fixtureName?: string;
+
   @Expose({ name: 'Markets' })
   @Type(() => Market)
   markets?: Market[];

--- a/test/entities/core-entities/market/market-event.spec.ts
+++ b/test/entities/core-entities/market/market-event.spec.ts
@@ -6,6 +6,7 @@ describe('MarketEvent Entity', () => {
   it('should deserialize a plain object into a MarketEvent instance', (): void => {
     const plain = {
       FixtureId: 123,
+      FixtureName: 'Premier League 2023/2024 Outright Winner',
       Markets: [
         { Id: 1, Name: 'Market1' },
         { Id: 2, Name: 'Market2' },
@@ -14,6 +15,7 @@ describe('MarketEvent Entity', () => {
     const event = plainToInstance(MarketEvent, plain, { excludeExtraneousValues: true });
     expect(event).toBeInstanceOf(MarketEvent);
     expect(event.fixtureId).toBe(123);
+    expect(event.fixtureName).toBe('Premier League 2023/2024 Outright Winner');
     expect(Array.isArray(event.markets)).toBe(true);
     expect(event.markets?.[0]).toBeInstanceOf(Market);
   });
@@ -22,6 +24,7 @@ describe('MarketEvent Entity', () => {
     const plain = {};
     const event = plainToInstance(MarketEvent, plain, { excludeExtraneousValues: true });
     expect(event.fixtureId).toBeUndefined();
+    expect(event.fixtureName).toBeUndefined();
     expect(event.markets).toBeUndefined();
   });
 

--- a/test/entities/core-entities/market/market-event.spec.ts
+++ b/test/entities/core-entities/market/market-event.spec.ts
@@ -28,6 +28,22 @@ describe('MarketEvent Entity', () => {
     expect(event.markets).toBeUndefined();
   });
 
+  it('should omit FixtureName when payload value is null or empty', (): void => {
+    const withNull = plainToInstance(
+      MarketEvent,
+      { FixtureId: 1, FixtureName: null },
+      { excludeExtraneousValues: true },
+    );
+    expect(withNull.fixtureName).toBeUndefined();
+
+    const withEmpty = plainToInstance(
+      MarketEvent,
+      { FixtureId: 1, FixtureName: '' },
+      { excludeExtraneousValues: true },
+    );
+    expect(withEmpty.fixtureName).toBeUndefined();
+  });
+
   it('should ignore extraneous properties', (): void => {
     const plain = {
       FixtureId: 456,

--- a/test/entities/core-entities/outright-league/nested-event-transform.spec.ts
+++ b/test/entities/core-entities/outright-league/nested-event-transform.spec.ts
@@ -34,6 +34,7 @@ describe('Outright league nested event transform (TR-23836)', () => {
         Events: [
           {
             FixtureId: 99,
+            FixtureName: 'Premier League 2023/2024 Outright Winner',
             Markets: [{ Id: 1, Name: 'M1', Bets: [{ Id: 2, Name: 'B1', Status: 1 }] }],
           },
         ],
@@ -66,6 +67,7 @@ describe('Outright league nested event transform (TR-23836)', () => {
 
     expect(event).toBeInstanceOf(MarketEvent);
     expect(event?.fixtureId).toBe(99);
+    expect(event?.fixtureName).toBe('Premier League 2023/2024 Outright Winner');
     expect(market?.id).toBe(1);
     expect(market?.name).toBe('M1');
     expect(bet?.id).toBe('2');
@@ -85,6 +87,7 @@ describe('Outright league nested event transform (TR-23836)', () => {
 
     expect(event).toBeInstanceOf(MarketEvent);
     expect(event?.fixtureId).toBe(99);
+    expect(event?.fixtureName).toBe('Premier League 2023/2024 Outright Winner');
     expect(event?.markets?.[0]?.bets?.[0]?.id).toBe('2');
   });
 });

--- a/test/entities/message-types/outright-league-market-update.spec.ts
+++ b/test/entities/message-types/outright-league-market-update.spec.ts
@@ -34,6 +34,7 @@ describe('OutrightLeagueMarketUpdate (type 40)', () => {
     const event = season?.events?.[0];
     expect(event).toBeInstanceOf(MarketEvent);
     expect(event?.fixtureId).toBe(26721036);
+    expect(event?.fixtureName).toBe('Premier League 2023/2024 Outright Winner');
 
     const market = event?.markets?.[0];
     expect(market?.id).toBe(274);

--- a/test/fixtures/outright-league-market-update-type40.json
+++ b/test/fixtures/outright-league-market-update-type40.json
@@ -12,6 +12,7 @@
         "Events": [
           {
             "FixtureId": 26721036,
+            "FixtureName": "Premier League 2023/2024 Outright Winner",
             "Livescore": null,
             "Markets": [
               {


### PR DESCRIPTION
# User description
## Summary
- Add optional `fixtureName` on `MarketEvent` used by **OutrightLeagueMarketUpdate (40)** and **OutrightLeagueSettlementUpdate (43)**
- Bump package version to **3.10.6**
- Update changelog, fixtures, and unit tests

Linear: [TRGN-1739](https://linear.app/lsports-ltd/issue/TRGN-1739/sdk-add-fixture-name-to-outrightleaguemarketsettlement-messages)

## Test plan
- [x] `market-event`, `outright-league-market-update`, `nested-event-transform` tests pass
- [ ] Verify deserialization of production payload with `FixtureName` present
- [ ] Verify field remains undefined when omitted from payload


Made with [Cursor](https://cursor.com)

---

# Generated description

Below is a concise technical summary of the changes proposed in this PR:
Add optional <code>fixtureName</code> support to <code>MarketEvent</code> deserialization for OutrightLeague market and settlement messages (types 40 and 43), omitting it when the payload is null or empty. Update package metadata, changelog, fixtures, and tests to document and validate the backward-compatible SDK enhancement.
<table><tr><th>Topic</th><th>Details</th><tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/116?tool=ast&topic=Fixture+name+support>Fixture name support</a>
        </td><td>Expose and deserialize <code>FixtureName</code> on nested <code>MarketEvent</code> instances for OutrightLeague market and settlement flows, while omitting absent, null, or empty values.<details><summary>Modified files (5)</summary><ul><li>src/entities/core-entities/market/market-event.ts</li>
<li>test/entities/core-entities/market/market-event.spec.ts</li>
<li>test/entities/core-entities/outright-league/nested-event-transform.spec.ts</li>
<li>test/entities/message-types/outright-league-market-update.spec.ts</li>
<li>test/fixtures/outright-league-market-update-type40.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>fix: omit null/empty F...</td><td>August 05, 2026</td></tr>
<tr><td>benny.h@lsports.eu</td><td>Metadata -  entities r...</td><td>November 10, 2024</td></tr></table></details></td></tr>
<tr><td><a href=https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/116?tool=ast&topic=SDK+release+update>SDK release update</a>
        </td><td>Publish the backward-compatible SDK enhancement as version 3.10.6 and record the new field behavior in the changelog.<details><summary>Modified files (3)</summary><ul><li>CHANGELOG.md</li>
<li>package-lock.json</li>
<li>package.json</li></ul></details><details><summary>Latest Contributors(2)</summary><table><tr><th>User</th><th>Commit</th><th>Date</th></tr><tr><td>shir.b@lsports.eu</td><td>feat: add FixtureName ...</td><td>August 05, 2026</td></tr>
<tr><td>gal.be@lsports.eu</td><td>Expose feedInterrupted...</td><td>July 28, 2026</td></tr></table></details></td></tr></table>
<sub><a href="https://baz.co/changes/lsportsltd/trade360-nodejs-sdk/116?tool=ast">Review this PR on Baz</a> | <a href="https://baz.co/agents/baz">Customize your next review</a></sub>